### PR TITLE
modify the environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -4,17 +4,17 @@ channels:
 dependencies:
   - python>=3.8
   - matplotlib>=3.5.2
-  - numpy
-  - pandas
-  - xarray
-  - netcdf4
-  - pyarrow
-  - zarr
-  - numba
-  - tqdm
-  - fsspec
-  - awkward
-  - llvmlite
-  - pip
+  - numpy>=1.21.6
+  - pandas>=1.4.4
+  - xarray>=2022.6.0
+  - netcdf4>=1.6.1
+  - pyarrow>=9.0.0
+  - zarr>=2.12.0
+  - numba>=0.55.0
+  - tqdm>=4.64.1
+  - fsspec>=2022.8.2
+  - awkward>=1.8.0
+  - llvmlite>=0.38.1
+  - pip>=22.2.2
   - pip:
     - git+https://github.com/philippemiron/clouddrift

--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,6 @@ dependencies:
   - tqdm>=4.64.0
   - fsspec>=2022.3.0
   - pip>=22.1.1
+  - awkward>=1.8.0
   - pip:
-    - awkward>=1.9.0
     - clouddrift

--- a/environment.yml
+++ b/environment.yml
@@ -16,4 +16,4 @@ dependencies:
   - pip>=22.1.1
   - awkward>=1.8.0
   - pip:
-    - clouddrift
+    - git+https://github.com/philippemiron/clouddrift

--- a/environment.yml
+++ b/environment.yml
@@ -15,6 +15,6 @@ dependencies:
   - fsspec>=2022.3.0
   - pip>=22.1.1
   - awkward>=1.8.0
-  - llvmlite>=0.39
+  - llvmlite>=0.39.1
   - pip:
     - git+https://github.com/philippemiron/clouddrift

--- a/environment.yml
+++ b/environment.yml
@@ -16,5 +16,5 @@ dependencies:
   - llvmlite>=0.38.1
   - pip>=22.2.2
   - pip:
-    - awkward>=1.9.0
+    - awkward==1.9.0
     - git+https://github.com/philippemiron/clouddrift

--- a/environment.yml
+++ b/environment.yml
@@ -13,8 +13,8 @@ dependencies:
   - numba>=0.55.0
   - tqdm>=4.64.1
   - fsspec>=2022.8.2
-  - awkward>=1.8.0
   - llvmlite>=0.38.1
   - pip>=22.2.2
   - pip:
+    - awkward>=1.9.0
     - git+https://github.com/philippemiron/clouddrift

--- a/environment.yml
+++ b/environment.yml
@@ -4,17 +4,17 @@ channels:
 dependencies:
   - python>=3.8
   - matplotlib>=3.5.2
-  - numpy>=1.22.4
-  - pandas>=1.4.2
-  - xarray>=2022.3.0
-  - netcdf4>=1.5.8
-  - pyarrow>=8.0.0
-  - zarr>=2.11.3
-  - numba>=0.53.1
-  - tqdm>=4.64.0
-  - fsspec>=2022.3.0
-  - pip>=22.1.1
-  - awkward>=1.8.0
-  - llvmlite>=0.39.1
+  - numpy
+  - pandas
+  - xarray
+  - netcdf4
+  - pyarrow
+  - zarr
+  - numba
+  - tqdm
+  - fsspec
+  - awkward
+  - llvmlite
+  - pip
   - pip:
     - git+https://github.com/philippemiron/clouddrift

--- a/environment.yml
+++ b/environment.yml
@@ -15,5 +15,6 @@ dependencies:
   - fsspec>=2022.3.0
   - pip>=22.1.1
   - awkward>=1.8.0
+  - llvmlite>=0.39
   - pip:
     - git+https://github.com/philippemiron/clouddrift

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "numba>=0.53.1",
     "tqdm>=4.64.0",
     "fsspec>=2022.3.0",
+    "llvmlite>=0.39",
     "awkward>=1.8.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ dependencies = [
     "numba>=0.53.1",
     "tqdm>=4.64.0",
     "fsspec>=2022.3.0",
-    "llvmlite>=0.39.1",
     "awkward>=1.8.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,16 +19,16 @@ classifiers = [
 ]
 
 dependencies = [
-    "numpy>=1.22.4",
-    "pandas>=1.4.2",
-    "xarray>=2022.3.0",
-    "netcdf4>=1.5.8",
-    "pyarrow>=8.0.0",
-    "zarr>=2.11.3",
-    "numba>=0.53.1",
-    "tqdm>=4.64.0",
-    "fsspec>=2022.3.0",
-    "awkward>=1.8.0",
+    "numpy",
+    "pandas",
+    "xarray",
+    "netcdf4",
+    "pyarrow",
+    "zarr",
+    "numba",
+    "tqdm",
+    "fsspec",
+    "awkward",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "numpy",
+    "numpy=1.22.4",
     "pandas",
     "xarray",
     "netcdf4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,14 @@ classifiers = [
 
 dependencies = [
     "numpy>=1.22.4",
-    "pandas",
-    "xarray",
-    "netcdf4",
-    "pyarrow",
-    "zarr",
-    "numba",
-    "tqdm",
-    "fsspec",
+    "pandas>=1.4.2",
+    "xarray>=2022.3.0",
+    "netcdf4>=1.5.8",
+    "pyarrow>=8.0.0",
+    "zarr>=2.11.3",
+    "numba>=0.53.1",
+    "tqdm>=4.64.0",
+    "fsspec>=2022.3.0",
     "awkward==1.9.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "numpy=1.22.4",
+    "numpy>=1.22.4",
     "pandas",
     "xarray",
     "netcdf4",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "numba>=0.53.1",
     "tqdm>=4.64.0",
     "fsspec>=2022.3.0",
-    "llvmlite>=0.39",
+    "llvmlite>=0.39.1",
     "awkward>=1.8.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "numba>=0.53.1",
     "tqdm>=4.64.0",
     "fsspec>=2022.3.0",
-    "awkward>=1.9.0",
+    "awkward>=1.8.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "numba",
     "tqdm",
     "fsspec",
-    "awkward",
+    "awkward==1.9.0",
 ]
 
 [project.urls]

--- a/tests/environment.yml
+++ b/tests/environment.yml
@@ -4,16 +4,17 @@ channels:
 dependencies:
   - python>=3.8
   - matplotlib>=3.5.2
-  - numpy>=1.22.4
-  - pandas>=1.4.2
-  - xarray>=2022.3.0
-  - netcdf4>=1.5.8
-  - pyarrow>=8.0.0
-  - zarr>=2.11.3
-  - numba>=0.53.1
-  - tqdm>=4.64.0
-  - fsspec>=2022.3.0
-  - pip>=22.1.1
+  - numpy>=1.21.6
+  - pandas>=1.4.4
+  - xarray>=2022.6.0
+  - netcdf4>=1.6.1
+  - pyarrow>=9.0.0
+  - zarr>=2.12.0
+  - numba>=0.55.0
+  - tqdm>=4.64.1
+  - fsspec>=2022.8.2
+  - llvmlite>=0.38.1
+  - pip>=22.2.2
   - pip:
     - awkward>=1.9.0
     - git+https://github.com/Cloud-Drift/clouddrift.git

--- a/tests/environment.yml
+++ b/tests/environment.yml
@@ -16,5 +16,5 @@ dependencies:
   - llvmlite>=0.38.1
   - pip>=22.2.2
   - pip:
-    - awkward>=1.9.0
+    - awkward==1.9.0
     - git+https://github.com/Cloud-Drift/clouddrift.git


### PR DESCRIPTION
This force the use of Awkward 1.9.0 and fixes the Binder, while still passing the tests (with 1.10.0, something changed but I don't have the time to figure it out right now). 

I believe it should be easier once Awkward array updates their conda packages, but we can modify later.