### PR TITLE
Remove unused dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,14 +3,10 @@ channels:
   - conda-forge
 dependencies:
   - python>=3.9
-  - matplotlib>=3.5.2
   - numpy>=1.21.6
-  - pandas>=1.4.4
   - xarray>=2022.6.0
   - netcdf4>=1.6.1
   - pyarrow>=9.0.0
-  - zarr>=2.12.0
-  - numba>=0.55.0
   - tqdm>=4.64.1
   - fsspec>=2022.8.2
   - llvmlite>=0.38.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clouddrift"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
   { name="Shane Elipot", email="selipot@miami.edu" },
   { name="Philippe Miron", email="philippemiron@gmail.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,9 @@ classifiers = [
 
 dependencies = [
     "numpy>=1.22.4",
-    "pandas>=1.4.2",
     "xarray>=2022.3.0",
     "netcdf4>=1.5.8",
     "pyarrow>=8.0.0",
-    "zarr>=2.11.3",
-    "numba>=0.53.1",
     "tqdm>=4.64.0",
     "fsspec>=2022.3.0",
     "awkward==1.9.0",

--- a/tests/environment.yml
+++ b/tests/environment.yml
@@ -3,14 +3,10 @@ channels:
   - conda-forge
 dependencies:
   - python>=3.9
-  - matplotlib>=3.5.2
   - numpy>=1.21.6
-  - pandas>=1.4.4
   - xarray>=2022.6.0
   - netcdf4>=1.6.1
   - pyarrow>=9.0.0
-  - zarr>=2.12.0
-  - numba>=0.55.0
   - tqdm>=4.64.1
   - fsspec>=2022.8.2
   - llvmlite>=0.38.1


### PR DESCRIPTION
This removes numba, pandas, and zarr dependencies for the core library, as well as matplotlib from the Conda env files. ~~Hopefully this should minimize or completely remove dependency version issues during PyPI packaging.~~ (never mind, it was the missing `--extra-index-url`)

Closes #41.