### PR TITLE
Fix awkward import

### DIFF
--- a/clouddrift/dataformat.py
+++ b/clouddrift/dataformat.py
@@ -1,7 +1,7 @@
 try:
-    import awkward._v2 as ak   # provides v2 in 1.8.0rc1<=awkward<=1.10.1
+    import awkward._v2 as ak  # provides v2 in 1.8.0rc1<=awkward<=1.10.1
 except ModuleNotFoundError:
-    import awkward as ak       # provides v2 in awkward>=2
+    import awkward as ak  # provides v2 in awkward>=2
 
 import xarray as xr
 import numpy as np

--- a/clouddrift/dataformat.py
+++ b/clouddrift/dataformat.py
@@ -1,4 +1,8 @@
-import awkward._v2 as ak
+try:
+    import awkward._v2 as ak   # provides v2 in 1.8.0rc1<=awkward<=1.10.1
+except ModuleNotFoundError:
+    import awkward as ak       # provides v2 in awkward>=2
+
 import xarray as xr
 import numpy as np
 from collections.abc import Callable

--- a/clouddrift/select.py
+++ b/clouddrift/select.py
@@ -1,4 +1,7 @@
-import awkward._v2 as ak
+try:
+    import awkward._v2 as ak   # provides v2 in 1.8.0rc1<=awkward<=1.10.1
+except ModuleNotFoundError:
+    import awkward as ak       # provides v2 in awkward>=2
 import numpy as np
 
 
@@ -69,9 +72,9 @@ def subset(ds: ak.Array, criteria: dict) -> ak.Array:
         print("Empty set.")
         return ak.Array([])
     else:  # apply the filtering for both dimensions
-        ds_subset = ak.packed(ds[mask_traj])
+        ds_subset = ak.to_packed(ds[mask_traj])
         ds_subset = ak.with_field(
-            ds_subset, ak.packed(ds.obs[mask_obs][mask_traj]), "obs"
+            ds_subset, ak.to_packed(ds.obs[mask_obs][mask_traj]), "obs"
         )
         ds_subset = ak.with_field(
             ds_subset, ak.Array([len(x) for x in ds_subset.obs.ids]), "rowsize"

--- a/clouddrift/select.py
+++ b/clouddrift/select.py
@@ -1,7 +1,7 @@
 try:
-    import awkward._v2 as ak   # provides v2 in 1.8.0rc1<=awkward<=1.10.1
+    import awkward._v2 as ak  # provides v2 in 1.8.0rc1<=awkward<=1.10.1
 except ModuleNotFoundError:
-    import awkward as ak       # provides v2 in awkward>=2
+    import awkward as ak  # provides v2 in awkward>=2
 import numpy as np
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clouddrift"
-version = "0.3.0"
+version = "0.3.1"
 authors = [
   { name="Shane Elipot", email="selipot@miami.edu" },
   { name="Philippe Miron", email="philippemiron@gmail.com" },

--- a/tests/dataformat_tests.py
+++ b/tests/dataformat_tests.py
@@ -4,10 +4,11 @@ import os
 import xarray as xr
 import numpy as np
 from clouddrift import RaggedArray
+
 try:
-    import awkward._v2 as ak   # provides v2 in 1.8.0rc1<=awkward<=1.10.1
+    import awkward._v2 as ak  # provides v2 in 1.8.0rc1<=awkward<=1.10.1
 except ModuleNotFoundError:
-    import awkward as ak       # provides v2 in awkward>=2
+    import awkward as ak  # provides v2 in awkward>=2
 
 NETCDF_ARCHIVE = "test_archive.nc"
 PARQUET_ARCHIVE = "test_archive.parquet"

--- a/tests/dataformat_tests.py
+++ b/tests/dataformat_tests.py
@@ -4,7 +4,10 @@ import os
 import xarray as xr
 import numpy as np
 from clouddrift import RaggedArray
-import awkward._v2 as ak
+try:
+    import awkward._v2 as ak   # provides v2 in 1.8.0rc1<=awkward<=1.10.1
+except ModuleNotFoundError:
+    import awkward as ak       # provides v2 in awkward>=2
 
 NETCDF_ARCHIVE = "test_archive.nc"
 PARQUET_ARCHIVE = "test_archive.parquet"

--- a/tests/select_tests.py
+++ b/tests/select_tests.py
@@ -2,10 +2,11 @@ import unittest
 from unittest import TestCase
 import numpy as np
 import xarray as xr
+
 try:
-    import awkward._v2 as ak   # provides v2 in 1.8.0rc1<=awkward<=1.10.1
+    import awkward._v2 as ak  # provides v2 in 1.8.0rc1<=awkward<=1.10.1
 except ModuleNotFoundError:
-    import awkward as ak       # provides v2 in awkward>=2
+    import awkward as ak  # provides v2 in awkward>=2
 from clouddrift import RaggedArray, select
 
 if __name__ == "__main__":

--- a/tests/select_tests.py
+++ b/tests/select_tests.py
@@ -2,7 +2,10 @@ import unittest
 from unittest import TestCase
 import numpy as np
 import xarray as xr
-import awkward._v2 as ak
+try:
+    import awkward._v2 as ak   # provides v2 in 1.8.0rc1<=awkward<=1.10.1
+except ModuleNotFoundError:
+    import awkward as ak       # provides v2 in awkward>=2
 from clouddrift import RaggedArray, select
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR:

* Changes the awkward import to the recommended try/except import to allow working with either <2 or >2. 
* Changes `ak.packed` to `ak.to_packed` which seems to have changed in the process, though I can't find the specific issue or PR right now.
* Bumps version to 0.3.1.

Previous releases will remain broken, which should be fine.

Closes #55.
