### PR TITLE
Velocity from positions

### DIFF
--- a/clouddrift/analysis.py
+++ b/clouddrift/analysis.py
@@ -1,11 +1,10 @@
-from datetime import datetime
 import numpy as np
 from typing import Optional, Tuple
 import xarray as xr
 from clouddrift.haversine import distance, bearing
 
 
-def velocity_from_positions(
+def velocity_from_position(
     x: np.ndarray,
     y: np.ndarray,
     time: np.ndarray,

--- a/clouddrift/analysis.py
+++ b/clouddrift/analysis.py
@@ -1,15 +1,16 @@
 from datetime import datetime
+import numpy as np
 from typing import Optional, Tuple
 import xarray as xr
 
 
 def velocity_from_positions(
-    x: xr.DataArray[float],
-    y: xr.DataArray[float],
-    time: xr.DataArray[datetime],
+    x: xr.DataArray,
+    y: xr.DataArray,
+    time: xr.DataArray,
     coord_system: Optional[str] = "spherical",
     difference_scheme: Optional[str] = "forward",
-) -> Tuple[xr.DataArray[float], xr.DataArray[float]]:
+) -> Tuple[xr.DataArray, xr.DataArray]:
     """Compute velocity in meters per second given arrays of positions and
     time.
 
@@ -28,7 +29,11 @@ def velocity_from_positions(
 
     Forward and backward schemes are effectively the same except that the
     position at which the velocity is evaluated is shifted one element down in
-    the backward scheme relative to the forward scheme.
+    the backward scheme relative to the forward scheme. In the case of a
+    forward or backward difference scheme, the last or first element of the
+    velocity, respectively, is extrapolated from its neighboring point. In the
+    case of a centered difference scheme, the start and end boundary points are
+    evaluated using the forward and backward difference scheme, respectively.
 
     Args:
         x (xr.DataArray[float]): An array of x-positions (longitude in degrees or easting in meters)
@@ -41,11 +46,76 @@ def velocity_from_positions(
         out (Tuple[xr.DataArray[float], xr.DataArray[float]]): Arrays of x- and y-velocities in meters per second
     """
 
-    # Check user input
-    if not coord_system in ["spherical", "cartesian"]:
-        raise ValueError('coord_system must be "spherical" or "cartesian".')
+    # Positions and time arrays must have the same shape.
+    if not x.shape == y.shape == time.shape:
+        raise ValueError("x, y, and time must have the same shape.")
 
-    if not difference_scheme in ["forward", "backward", "centered"]:
+    #FIXME DataArray construction
+    dx = xr.DataArray(x.shape)
+    dy = xr.DataArray(y.shape)
+    dt = xr.DataArray(time.shape)
+
+    # Compute dx, dy, and dt
+    if difference_scheme == "forward":
+
+        # Time
+        dt[:-1] = np.diff(time)
+        dt[-1] = dt[-2]
+
+        # Space
+        if coord_system == "cartesian":
+            dx[:-1] = np.diff(x)
+            dx[-1] = dx[-2]
+            dy[:-1] = np.diff(y)
+            dy[-1] = dy[-2]
+        elif coord_system == "spherical":
+            # TODO compute Haversine (distance, bearing) -> (dx, dy)
+            raise NotImplementedError()
+        else:
+            raise ValueError('coord_system must be "spherical" or "cartesian".')
+
+    elif difference_scheme == "backward":
+
+        # Time
+        dt[1:] = np.diff(time)
+        dt[0] = dt[1]
+
+        # Space
+        if coord_system == "cartesian":
+            dx[1:] = np.diff(x)
+            dx[0] = dx[1]
+            dy[1:] = np.diff(y)
+            dy[0] = dy[1]
+        elif coord_system == "spherical":
+            # TODO compute Haversine (distance, bearing) -> (dx, dy)
+            raise NotImplementedError()
+        else:
+            raise ValueError('coord_system must be "spherical" or "cartesian".')
+
+    elif difference_scheme == "centered":
+
+        # Time
+        dt[1:-1] = (time[2:] - time[:-2]) / 2
+        dt[0] = time[1] - time[0]
+        dt[-1] = time[-1] - time[-2]
+
+        # Space
+        if coord_system == "cartesian":
+            dx[1:-1] = (x[2:] - x[:-2]) / 2
+            dx[0] = x[1] - x[0]
+            dx[-1] = x[-1] - x[-2]
+            dy[1:-1] = (y[2:] - y[:-2]) / 2
+            dy[0] = y[1] - y[0]
+            dy[-1] = y[-1] - y[-2]
+        elif coord_system == "spherical":
+            # TODO compute Haversine (distance, bearing) -> (dx, dy)
+            raise NotImplementedError()
+        else:
+            raise ValueError('coord_system must be "spherical" or "cartesian".')
+
+    else:
         raise ValueError(
             'difference_scheme must be "forward", "backward", or "centered".'
         )
+
+    return dx / dt, dy / dt

--- a/clouddrift/analysis.py
+++ b/clouddrift/analysis.py
@@ -39,7 +39,7 @@ def velocity_from_positions(
     Args:
         x (xr.DataArray[float]): An array of x-positions (longitude in degrees or easting in meters)
         y (xr.DataArray[float]): An array of y-positions (latitude in degrees or northing in meters)
-        time (xr.DataArray[datetime]): An array of times
+        time (xr.DataArray[float]): An array of times as floating point seconds since epoch
         coord_system (str, optional): Coordinate system that x and y arrays are in; possible values are "spherical" (default) or "cartesian".
         difference_scheme (str, optional): Difference scheme to use; possible values are "forward", "backward", and "centered".
 
@@ -52,8 +52,8 @@ def velocity_from_positions(
         raise ValueError("x, y, and time must have the same shape.")
 
     dx = xr.zeros_like(x)
-    dy = xr.zeros_like(y.shape)
-    dt = xr.zeros_like(time.shape)
+    dy = xr.zeros_like(y)
+    dt = xr.zeros_like(time)
 
     # Compute dx, dy, and dt
     if difference_scheme == "forward":

--- a/clouddrift/analysis.py
+++ b/clouddrift/analysis.py
@@ -71,9 +71,9 @@ def velocity_from_positions(
         elif coord_system == "spherical":
             distances = distance(y[:-1], x[:-1], y[1:], x[1:])
             bearings = bearing(y[:-1], x[:-1], y[1:], x[1:])
-            dx[:-1] = distances * np.sin(bearings)
+            dx[:-1] = distances * np.cos(bearings)
             dx[-1] = dx[-2]
-            dy[:-1] = distances * np.cos(bearings)
+            dy[:-1] = distances * np.sin(bearings)
             dy[-1] = dy[-2]
         else:
             raise ValueError('coord_system must be "spherical" or "cartesian".')
@@ -93,9 +93,9 @@ def velocity_from_positions(
         elif coord_system == "spherical":
             distances = distance(y[:-1], x[:-1], y[1:], x[1:])
             bearings = bearing(y[:-1], x[:-1], y[1:], x[1:])
-            dx[1:] = distances * np.sin(bearings)
+            dx[1:] = distances * np.cos(bearings)
             dx[0] = dx[1]
-            dy[1:] = distances * np.cos(bearings)
+            dy[1:] = distances * np.sin(bearings)
             dy[0] = dy[1]
         else:
             raise ValueError('coord_system must be "spherical" or "cartesian".')
@@ -118,10 +118,10 @@ def velocity_from_positions(
         elif coord_system == "spherical":
             distances = distance(y[:-2], x[:-2], y[2:], x[2:])
             bearings = bearing(y[:-2], x[:-2], y[2:], x[2:])
-            dx[1:-1] = distances * np.sin(bearings) / 2
+            dx[1:-1] = distances * np.cos(bearings) / 2
             dx[0] = dx[1]  # FIXME
             dx[-1] = dx[-2]  # FIXME
-            dy[1:-1] = distances * np.cos(bearings) / 2
+            dy[1:-1] = distances * np.sin(bearings) / 2
             dy[0] = dy[1]  # FIXME
             dy[-1] = dy[-2]  # FIXME
         else:

--- a/clouddrift/analysis.py
+++ b/clouddrift/analysis.py
@@ -1,0 +1,36 @@
+from datetime import datetime
+from typing import Optional, Tuple
+import xarray as xr
+
+
+def velocity_from_positions(
+    x: xr.DataArray[float],
+    y: xr.DataArray[float],
+    time: xr.DataArray[datetime],
+    coord_system: Optional[str] = "spherical",
+    difference_scheme: Optional[str] = "forward",
+) -> Tuple[xr.DataArray[float], xr.DataArray[float]]:
+    """Compute velocity in meters per second given arrays of positions and
+    time.
+
+    x and y can be provided as longitude and latitude in degrees if
+    coord_system == "spherical" (default), or as northing and easting in meters
+    if coord_system == "cartesian".
+
+    Difference scheme can take one of three values:
+
+        1. "forward" (default): finite difference is evaluated as dx[i] = dx[i+1] - dx[i];
+        2. "backward": finite difference is evaluated as dx[i] = dx[i] - dx[i-1];
+        3. "centered": finite difference is evaluated as dx[i] = (dx[i+1] - dx[i-1]) / 2.
+
+    Args:
+        x (xr.DataArray[float]): An array of x-positions (longitude in degrees or easting in meters)
+        y (xr.DataArray[float]): An array of y-positions (latitude in degrees or northing in meters)
+        time (xr.DataArray[datetime]): An array of times
+        coord_system (str, optional): Coordinate system that x and y arrays are in; possible values are "spherical" (default) or "cartesian".
+        difference_scheme (str, optional): Difference scheme to use; possible values are "forward", "backward", and "centered".
+
+    Returns:
+        out (Tuple[xr.DataArray[float], xr.DataArray[float]]): Arrays of x- and y-velocities in meters per second
+    """
+    raise NotImplementedError()

--- a/clouddrift/analysis.py
+++ b/clouddrift/analysis.py
@@ -58,27 +58,39 @@ def velocity_from_positions(
     # Compute dx, dy, and dt
     if difference_scheme == "forward":
 
+        # All values except the ending boundary value are computed using the
+        # 1st order forward differencing. The ending boundary value is
+        # computed using the 1st order backward difference.
+
         # Time
         dt[:-1] = np.diff(time)
         dt[-1] = dt[-2]
 
         # Space
         if coord_system == "cartesian":
+
             dx[:-1] = np.diff(x)
             dx[-1] = dx[-2]
             dy[:-1] = np.diff(y)
             dy[-1] = dy[-2]
+
         elif coord_system == "spherical":
+
             distances = distance(y[:-1], x[:-1], y[1:], x[1:])
             bearings = bearing(y[:-1], x[:-1], y[1:], x[1:])
             dx[:-1] = distances * np.cos(bearings)
             dx[-1] = dx[-2]
             dy[:-1] = distances * np.sin(bearings)
             dy[-1] = dy[-2]
+
         else:
             raise ValueError('coord_system must be "spherical" or "cartesian".')
 
     elif difference_scheme == "backward":
+
+        # All values except the starting boundary value are computed using the
+        # 1st order backward differencing. The starting boundary value is
+        # computed using the 1st order forward difference.
 
         # Time
         dt[1:] = np.diff(time)
@@ -86,21 +98,29 @@ def velocity_from_positions(
 
         # Space
         if coord_system == "cartesian":
+
             dx[1:] = np.diff(x)
             dx[0] = dx[1]
             dy[1:] = np.diff(y)
             dy[0] = dy[1]
+
         elif coord_system == "spherical":
+
             distances = distance(y[:-1], x[:-1], y[1:], x[1:])
             bearings = bearing(y[:-1], x[:-1], y[1:], x[1:])
             dx[1:] = distances * np.cos(bearings)
             dx[0] = dx[1]
             dy[1:] = distances * np.sin(bearings)
             dy[0] = dy[1]
+
         else:
             raise ValueError('coord_system must be "spherical" or "cartesian".')
 
     elif difference_scheme == "centered":
+
+        # Inner values are computed using the 2nd order centered differencing.
+        # The start and end boundary values are computed using the 1st order
+        # forward and backward differencing, respectively.
 
         # Time
         dt[1:-1] = (time[2:] - time[:-2]) / 2
@@ -109,21 +129,32 @@ def velocity_from_positions(
 
         # Space
         if coord_system == "cartesian":
+
             dx[1:-1] = (x[2:] - x[:-2]) / 2
             dx[0] = x[1] - x[0]
             dx[-1] = x[-1] - x[-2]
             dy[1:-1] = (y[2:] - y[:-2]) / 2
             dy[0] = y[1] - y[0]
             dy[-1] = y[-1] - y[-2]
+
         elif coord_system == "spherical":
+
+            # Inner values
             distances = distance(y[:-2], x[:-2], y[2:], x[2:])
             bearings = bearing(y[:-2], x[:-2], y[2:], x[2:])
             dx[1:-1] = distances * np.cos(bearings) / 2
-            dx[0] = dx[1]  # FIXME
-            dx[-1] = dx[-2]  # FIXME
             dy[1:-1] = distances * np.sin(bearings) / 2
-            dy[0] = dy[1]  # FIXME
-            dy[-1] = dy[-2]  # FIXME
+
+            # Boundary values
+            distance1 = distance(y[0], x[0], y[1], x[1])
+            bearing1 = bearing(y[0], x[0], y[1], x[1])
+            dx[0] = distance1 * np.cos(bearing1)
+            dy[0] = distance1 * np.sin(bearing1)
+            distance2 = distance(y[-2], x[-2], y[-1], x[-1])
+            bearing2 = bearing(y[-2], x[-2], y[-1], x[-1])
+            dx[-1] = distance2 * np.cos(bearing2)
+            dy[-1] = distance2 * np.sin(bearing2)
+
         else:
             raise ValueError('coord_system must be "spherical" or "cartesian".')
 

--- a/clouddrift/analysis.py
+++ b/clouddrift/analysis.py
@@ -6,9 +6,9 @@ from clouddrift.haversine import distance, bearing
 
 
 def velocity_from_positions(
-    x: xr.DataArray,
-    y: xr.DataArray,
-    time: xr.DataArray,
+    x: np.ndarray,
+    y: np.ndarray,
+    time: np.ndarray,
     coord_system: Optional[str] = "spherical",
     difference_scheme: Optional[str] = "forward",
 ) -> Tuple[xr.DataArray, xr.DataArray]:
@@ -37,9 +37,9 @@ def velocity_from_positions(
     evaluated using the forward and backward difference scheme, respectively.
 
     Args:
-        x (xr.DataArray[float]): An array of x-positions (longitude in degrees or easting in meters)
-        y (xr.DataArray[float]): An array of y-positions (latitude in degrees or northing in meters)
-        time (xr.DataArray[float]): An array of times as floating point seconds since epoch
+        x (array_like): An array of x-positions (longitude in degrees or easting in meters)
+        y (array_like): An array of y-positions (latitude in degrees or northing in meters)
+        time (array_like): An array of times as floating point seconds since epoch
         coord_system (str, optional): Coordinate system that x and y arrays are in; possible values are "spherical" (default) or "cartesian".
         difference_scheme (str, optional): Difference scheme to use; possible values are "forward", "backward", and "centered".
 
@@ -51,9 +51,9 @@ def velocity_from_positions(
     if not x.shape == y.shape == time.shape:
         raise ValueError("x, y, and time must have the same shape.")
 
-    dx = xr.zeros_like(x)
-    dy = xr.zeros_like(y)
-    dt = xr.zeros_like(time)
+    dx = np.empty(x.shape)
+    dy = np.empty(y.shape)
+    dt = np.empty(time.shape)
 
     # Compute dx, dy, and dt
     if difference_scheme == "forward":

--- a/clouddrift/analysis.py
+++ b/clouddrift/analysis.py
@@ -19,9 +19,16 @@ def velocity_from_positions(
 
     Difference scheme can take one of three values:
 
-        1. "forward" (default): finite difference is evaluated as dx[i] = dx[i+1] - dx[i];
-        2. "backward": finite difference is evaluated as dx[i] = dx[i] - dx[i-1];
-        3. "centered": finite difference is evaluated as dx[i] = (dx[i+1] - dx[i-1]) / 2.
+        1. "forward" (default): finite difference is evaluated as
+           dx[i] = dx[i+1] - dx[i];
+        2. "backward": finite difference is evaluated as
+           dx[i] = dx[i] - dx[i-1];
+        3. "centered": finite difference is evaluated as
+           dx[i] = (dx[i+1] - dx[i-1]) / 2.
+
+    Forward and backward schemes are effectively the same except that the
+    position at which the velocity is evaluated is shifted one element down in
+    the backward scheme relative to the forward scheme.
 
     Args:
         x (xr.DataArray[float]): An array of x-positions (longitude in degrees or easting in meters)
@@ -33,4 +40,12 @@ def velocity_from_positions(
     Returns:
         out (Tuple[xr.DataArray[float], xr.DataArray[float]]): Arrays of x- and y-velocities in meters per second
     """
-    raise NotImplementedError()
+
+    # Check user input
+    if not coord_system in ["spherical", "cartesian"]:
+        raise ValueError('coord_system must be "spherical" or "cartesian".')
+
+    if not difference_scheme in ["forward", "backward", "centered"]:
+        raise ValueError(
+            'difference_scheme must be "forward", "backward", or "centered".'
+        )

--- a/clouddrift/haversine.py
+++ b/clouddrift/haversine.py
@@ -45,15 +45,15 @@ def distance(
 def bearing(
     lat1: np.ndarray, lon1: np.ndarray, lat2: np.ndarray, lon2: np.ndarray
 ) -> np.ndarray:
-    """Return elementwise Haversine initial (forward) bearing in radians from
-    arrays of latitude and longitude in degrees.
+    """Return elementwise initial (forward) bearing in radians from arrays of
+    latitude and longitude in degrees, based on the spherical law of cosines.
 
     The formula is:
 
-    θ = atan2(sin Δλ ⋅ cos φ2, cos φ1 ⋅ sin φ2 - sin φ1 ⋅ cos φ2 ⋅ cos Δλ)
+    θ = atan2(cos φ1 ⋅ sin φ2 - sin φ1 ⋅ cos φ2 ⋅ cos Δλ, sin Δλ ⋅ cos φ2)
 
     where (φ, λ) is (lat, lon) and θ is bearing, all in radians.
-    Bearing is defined as zero toward North and increasing clockwise.
+    Bearing is defined as zero toward East and increasing counter-clockwise.
 
     Args:
         lat1 (array_like): Latitudes of the first set of points
@@ -74,9 +74,9 @@ def bearing(
     dlon = lon2_rad - lon1_rad
 
     theta = np.arctan2(
-        np.sin(dlon) * np.cos(lat2_rad),
         np.cos(lat1) * np.sin(lat2_rad)
         - np.sin(lat1_rad) * np.cos(lat2_rad) * np.cos(dlon),
+        np.sin(dlon) * np.cos(lat2_rad),
     )
 
     return theta

--- a/clouddrift/haversine.py
+++ b/clouddrift/haversine.py
@@ -1,0 +1,82 @@
+import numpy as np
+
+EARTH_RADIUS_METERS = 6.3781e6
+
+
+def distance(
+    lat1: np.ndarray, lon1: np.ndarray, lat2: np.ndarray, lon2: np.ndarray
+) -> np.ndarray:
+    """Return elementwise great circle distance in meters between one or more
+    points from arrays of their latitudes and longitudes, using the Haversine
+    formula.
+
+    d = 2⋅r⋅asin √[sin²(Δφ/2) + cos φ1 ⋅ cos φ2 ⋅ sin²(Δλ/2)]
+
+    where (φ, λ) is (lat, lon) in radians and r is the radius of the sphere in
+    meters.
+
+    Args:
+        lat1 (array_like): Latitudes of the first set of points
+        lon1 (array_like): Longitudes of the first set of points
+        lat2 (array_like): Latitudes of the second set of points
+        lon2 (array_like): Longitudes of the second set of points
+
+    Returns:
+        out (array_like): Great circle distance
+    """
+
+    # Input coordinates are in degrees; convert to radians.
+    lat1_rad = np.deg2rad(lat1)
+    lon1_rad = np.deg2rad(lon1)
+    lat2_rad = np.deg2rad(lat2)
+    lon2_rad = np.deg2rad(lon2)
+
+    dlat = lat2_rad - lat1_rad
+    dlon = lon2_rad - lon1_rad
+
+    h = (
+        np.sin(0.5 * dlat) ** 2
+        + np.cos(lat1_rad) * np.cos(lat2_rad) * np.sin(0.5 * dlon) ** 2
+    )
+
+    return 2 * np.arcsin(np.sqrt(h)) * EARTH_RADIUS_METERS
+
+
+def bearing(
+    lat1: np.ndarray, lon1: np.ndarray, lat2: np.ndarray, lon2: np.ndarray
+) -> np.ndarray:
+    """Return elementwise Haversine initial (forward) bearing in radians from
+    arrays of latitude and longitude in degrees.
+
+    The formula is:
+
+    θ = atan2(sin Δλ ⋅ cos φ2, cos φ1 ⋅ sin φ2 - sin φ1 ⋅ cos φ2 ⋅ cos Δλ)
+
+    where (φ, λ) is (lat, lon) and θ is bearing, all in radians.
+    Bearing is defined as zero toward North and increasing clockwise.
+
+    Args:
+        lat1 (array_like): Latitudes of the first set of points
+        lon1 (array_like): Longitudes of the first set of points
+        lat2 (array_like): Latitudes of the second set of points
+        lon2 (array_like): Longitudes of the second set of points
+
+    Returns:
+        theta (array_like): Bearing angles in radians
+    """
+
+    # Input coordinates are in degrees; convert to radians.
+    lat1_rad = np.deg2rad(lat1)
+    lon1_rad = np.deg2rad(lon1)
+    lat2_rad = np.deg2rad(lat2)
+    lon2_rad = np.deg2rad(lon2)
+
+    dlon = lon2_rad - lon1_rad
+
+    theta = np.arctan2(
+        np.sin(dlon) * np.cos(lat2_rad),
+        np.cos(lat1) * np.sin(lat2_rad)
+        - np.sin(lat1_rad) * np.cos(lat2_rad) * np.cos(dlon),
+    )
+
+    return theta

--- a/clouddrift/haversine.py
+++ b/clouddrift/haversine.py
@@ -74,7 +74,7 @@ def bearing(
     dlon = lon2_rad - lon1_rad
 
     theta = np.arctan2(
-        np.cos(lat1) * np.sin(lat2_rad)
+        np.cos(lat1_rad) * np.sin(lat2_rad)
         - np.sin(lat1_rad) * np.cos(lat2_rad) * np.cos(dlon),
         np.sin(dlon) * np.cos(lat2_rad),
     )

--- a/clouddrift/haversine.py
+++ b/clouddrift/haversine.py
@@ -1,4 +1,5 @@
 import numpy as np
+import xarray as xr
 
 EARTH_RADIUS_METERS = 6.3781e6
 
@@ -16,20 +17,34 @@ def distance(
     meters.
 
     Args:
-        lat1 (array_like): Latitudes of the first set of points
-        lon1 (array_like): Longitudes of the first set of points
-        lat2 (array_like): Latitudes of the second set of points
-        lon2 (array_like): Longitudes of the second set of points
+        lat1 (array_like): Latitudes of the first set of points, in degrees
+        lon1 (array_like): Longitudes of the first set of points, in degrees
+        lat2 (array_like): Latitudes of the second set of points, in degrees
+        lon2 (array_like): Longitudes of the second set of points, in degrees
 
     Returns:
         out (array_like): Great circle distance
     """
 
     # Input coordinates are in degrees; convert to radians.
-    lat1_rad = np.deg2rad(lat1)
-    lon1_rad = np.deg2rad(lon1)
-    lat2_rad = np.deg2rad(lat2)
-    lon2_rad = np.deg2rad(lon2)
+    # If any of the input arrays are xr.DataArray, extract the values first
+    # because Xarray enforces alignment between coordinates.
+    if type(lat1) is xr.DataArray:
+        lat1_rad = np.deg2rad(lat1.values)
+    else:
+        lat1_rad = np.deg2rad(lat1)
+    if type(lon1) is xr.DataArray:
+        lon1_rad = np.deg2rad(lon1.values)
+    else:
+        lon1_rad = np.deg2rad(lon1)
+    if type(lat2) is xr.DataArray:
+        lat2_rad = np.deg2rad(lat2.values)
+    else:
+        lat2_rad = np.deg2rad(lat2)
+    if type(lon2) is xr.DataArray:
+        lon2_rad = np.deg2rad(lon2.values)
+    else:
+        lon2_rad = np.deg2rad(lon2)
 
     dlat = lat2_rad - lat1_rad
     dlon = lon2_rad - lon1_rad
@@ -56,20 +71,34 @@ def bearing(
     Bearing is defined as zero toward East and increasing counter-clockwise.
 
     Args:
-        lat1 (array_like): Latitudes of the first set of points
-        lon1 (array_like): Longitudes of the first set of points
-        lat2 (array_like): Latitudes of the second set of points
-        lon2 (array_like): Longitudes of the second set of points
+        lat1 (array_like): Latitudes of the first set of points, in degrees
+        lon1 (array_like): Longitudes of the first set of points, in degrees
+        lat2 (array_like): Latitudes of the second set of points, in degrees
+        lon2 (array_like): Longitudes of the second set of points, in degrees
 
     Returns:
         theta (array_like): Bearing angles in radians
     """
 
     # Input coordinates are in degrees; convert to radians.
-    lat1_rad = np.deg2rad(lat1)
-    lon1_rad = np.deg2rad(lon1)
-    lat2_rad = np.deg2rad(lat2)
-    lon2_rad = np.deg2rad(lon2)
+    # If any of the input arrays are xr.DataArray, extract the values first
+    # because Xarray enforces alignment between coordinates.
+    if type(lat1) is xr.DataArray:
+        lat1_rad = np.deg2rad(lat1.values)
+    else:
+        lat1_rad = np.deg2rad(lat1)
+    if type(lon1) is xr.DataArray:
+        lon1_rad = np.deg2rad(lon1.values)
+    else:
+        lon1_rad = np.deg2rad(lon1)
+    if type(lat2) is xr.DataArray:
+        lat2_rad = np.deg2rad(lat2.values)
+    else:
+        lat2_rad = np.deg2rad(lat2)
+    if type(lon2) is xr.DataArray:
+        lon2_rad = np.deg2rad(lon2.values)
+    else:
+        lon2_rad = np.deg2rad(lon2)
 
     dlon = lon2_rad - lon1_rad
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clouddrift"
-version = "0.3.1"
+version = "0.4.0"
 authors = [
   { name="Shane Elipot", email="selipot@miami.edu" },
   { name="Philippe Miron", email="philippemiron@gmail.com" },

--- a/tests/analysis_tests.py
+++ b/tests/analysis_tests.py
@@ -1,4 +1,4 @@
-from clouddrift.analysis import velocity_from_positions
+from clouddrift.analysis import velocity_from_position
 from clouddrift.haversine import EARTH_RADIUS_METERS
 import unittest
 import numpy as np
@@ -9,17 +9,17 @@ if __name__ == "__main__":
     unittest.main()
 
 
-class velocity_from_positions_tests(unittest.TestCase):
+class velocity_from_position_tests(unittest.TestCase):
     def setUp(self):
         self.INPUT_SIZE = 100
         self.lon = np.rad2deg(np.linspace(-np.pi, np.pi, self.INPUT_SIZE))
         self.lat = np.zeros(self.lon.shape)
         self.time = np.linspace(0, 1e7, self.INPUT_SIZE)
-        self.uf, self.vf = velocity_from_positions(self.lon, self.lat, self.time)
-        self.ub, self.vb = velocity_from_positions(
+        self.uf, self.vf = velocity_from_position(self.lon, self.lat, self.time)
+        self.ub, self.vb = velocity_from_position(
             self.lon, self.lat, self.time, difference_scheme="backward"
         )
-        self.uc, self.vc = velocity_from_positions(
+        self.uc, self.vc = velocity_from_position(
             self.lon, self.lat, self.time, difference_scheme="centered"
         )
 
@@ -46,6 +46,6 @@ class velocity_from_positions_tests(unittest.TestCase):
         lon = xr.DataArray(data=self.lon, coords={"time": self.time})
         lat = xr.DataArray(data=self.lat, coords={"time": self.time})
         time = xr.DataArray(data=self.time, coords={"time": self.time})
-        uf, vf = velocity_from_positions(lon, lat, time)
+        uf, vf = velocity_from_position(lon, lat, time)
         self.assertTrue(np.all(uf == self.uf))
         self.assertTrue(np.all(vf == self.vf))

--- a/tests/analysis_tests.py
+++ b/tests/analysis_tests.py
@@ -1,0 +1,51 @@
+from clouddrift.analysis import velocity_from_positions
+from clouddrift.haversine import EARTH_RADIUS_METERS
+import unittest
+import numpy as np
+import xarray as xr
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class velocity_from_positions_tests(unittest.TestCase):
+    def setUp(self):
+        self.INPUT_SIZE = 100
+        self.lon = np.rad2deg(np.linspace(-np.pi, np.pi, self.INPUT_SIZE))
+        self.lat = np.zeros(self.lon.shape)
+        self.time = np.linspace(0, 1e7, self.INPUT_SIZE)
+        self.uf, self.vf = velocity_from_positions(self.lon, self.lat, self.time)
+        self.ub, self.vb = velocity_from_positions(
+            self.lon, self.lat, self.time, difference_scheme="backward"
+        )
+        self.uc, self.vc = velocity_from_positions(
+            self.lon, self.lat, self.time, difference_scheme="centered"
+        )
+
+    def test_result_has_same_size_as_input(self):
+        self.assertTrue(np.all(self.uf.shape == self.vf.shape == self.lon.shape))
+        self.assertTrue(np.all(self.ub.shape == self.vb.shape == self.lon.shape))
+        self.assertTrue(np.all(self.uc.shape == self.vc.shape == self.lon.shape))
+
+    def test_schemes_are_self_consistent(self):
+        self.assertTrue(np.all(self.uf[:-1] == self.ub[1:]))
+        self.assertTrue(
+            np.all(np.isclose((self.uf[1:-1] + self.ub[1:-1]) / 2, self.uc[1:-1]))
+        )
+        self.assertTrue(self.uc[0] == self.uf[0])
+        self.assertTrue(self.uc[-1] == self.ub[-1])
+
+    def test_result_value(self):
+        u_expected = 2 * np.pi * EARTH_RADIUS_METERS / 1e7
+        self.assertTrue(np.all(np.isclose(self.uf, u_expected)))
+        self.assertTrue(np.all(np.isclose(self.ub, u_expected)))
+        self.assertTrue(np.all(np.isclose(self.uc, u_expected)))
+
+    def test_works_with_dataarray(self):
+        lon = xr.DataArray(data=self.lon, coords={"time": self.time})
+        lat = xr.DataArray(data=self.lat, coords={"time": self.time})
+        time = xr.DataArray(data=self.time, coords={"time": self.time})
+        uf, vf = velocity_from_positions(lon, lat, time)
+        self.assertTrue(np.all(uf == self.uf))
+        self.assertTrue(np.all(vf == self.vf))

--- a/tests/haversine_tests.py
+++ b/tests/haversine_tests.py
@@ -8,25 +8,37 @@ if __name__ == "__main__":
 
 one_degree_meters = 2 * np.pi * EARTH_RADIUS_METERS / 360
 
-class haversine_tests(unittest.TestCase):
 
+class haversine_tests(unittest.TestCase):
     def test_distance_one_degree(self):
-        self.assertTrue(np.isclose(distance(0, 0, 0, 1), one_degree_meters)) 
-        self.assertTrue(np.isclose(distance(0, 0, 1, 0), one_degree_meters)) 
-        self.assertTrue(np.isclose(distance(0, 0, 0, -1), one_degree_meters)) 
-        self.assertTrue(np.isclose(distance(0, 0, -1, 0), one_degree_meters)) 
-    
+        self.assertTrue(np.isclose(distance(0, 0, 0, 1), one_degree_meters))
+        self.assertTrue(np.isclose(distance(0, 0, 1, 0), one_degree_meters))
+        self.assertTrue(np.isclose(distance(0, 0, 0, -1), one_degree_meters))
+        self.assertTrue(np.isclose(distance(0, 0, -1, 0), one_degree_meters))
+
     def test_distance_arraylike(self):
-        self.assertTrue(np.all(np.isclose(
-            distance([0, 0], [0, 0], [0, 0], [1, 1]),
-            np.array(2 * [one_degree_meters])
-        )))
+        self.assertTrue(
+            np.all(
+                np.isclose(
+                    distance([0, 0], [0, 0], [0, 0], [1, 1]),
+                    np.array(2 * [one_degree_meters]),
+                )
+            )
+        )
 
     def test_distance_antimeridian(self):
-        self.assertTrue(np.isclose(distance(0, 179.5, 0, -179.5), one_degree_meters)) 
-        self.assertTrue(np.isclose(distance(0, -179.5, 0, 179.5), one_degree_meters)) 
-        self.assertTrue(np.isclose(distance(0, 359.5, 0, 360.5), one_degree_meters)) 
-        self.assertTrue(np.isclose(distance(0, 360.5, 0, 359.5), one_degree_meters)) 
+        self.assertTrue(
+            np.isclose(distance(0, 179.5, 0, -179.5), one_degree_meters)
+        )
+        self.assertTrue(
+            np.isclose(distance(0, -179.5, 0, 179.5), one_degree_meters)
+        )
+        self.assertTrue(
+            np.isclose(distance(0, 359.5, 0, 360.5), one_degree_meters)
+        )
+        self.assertTrue(
+            np.isclose(distance(0, 360.5, 0, 359.5), one_degree_meters)
+        )
 
     def test_bearing(self):
         self.assertTrue(np.isclose(bearing(0, 0, 0.1, 0), 0))
@@ -34,6 +46,6 @@ class haversine_tests(unittest.TestCase):
         self.assertTrue(np.isclose(bearing(0, 0, 0, 0.1), np.pi / 2))
         self.assertTrue(np.isclose(bearing(0, 0, -0.1, 0.1), 3 / 4 * np.pi))
         self.assertTrue(np.isclose(bearing(0, 0, -0.1, 0), np.pi))
-        self.assertTrue(np.isclose(bearing(0, 0, -0.1, -0.1), - 3 / 4 * np.pi))
-        self.assertTrue(np.isclose(bearing(0, 0, 0, -0.1), - np.pi / 2))
-        self.assertTrue(np.isclose(bearing(0, 0, 0.1, -0.1), - np.pi / 4))
+        self.assertTrue(np.isclose(bearing(0, 0, -0.1, -0.1), -3 / 4 * np.pi))
+        self.assertTrue(np.isclose(bearing(0, 0, 0, -0.1), -np.pi / 2))
+        self.assertTrue(np.isclose(bearing(0, 0, 0.1, -0.1), -np.pi / 4))

--- a/tests/haversine_tests.py
+++ b/tests/haversine_tests.py
@@ -41,11 +41,11 @@ class haversine_tests(unittest.TestCase):
         )
 
     def test_bearing(self):
-        self.assertTrue(np.isclose(bearing(0, 0, 0.1, 0), 0))
+        self.assertTrue(np.isclose(bearing(0, 0, 0, 0.1), 0))
         self.assertTrue(np.isclose(bearing(0, 0, 0.1, 0.1), np.pi / 4))
-        self.assertTrue(np.isclose(bearing(0, 0, 0, 0.1), np.pi / 2))
-        self.assertTrue(np.isclose(bearing(0, 0, -0.1, 0.1), 3 / 4 * np.pi))
-        self.assertTrue(np.isclose(bearing(0, 0, -0.1, 0), np.pi))
+        self.assertTrue(np.isclose(bearing(0, 0, 0.1, 0), np.pi / 2))
+        self.assertTrue(np.isclose(bearing(0, 0, 0.1, -0.1), 3 / 4 * np.pi))
+        self.assertTrue(np.isclose(bearing(0, 0, 0, -0.1), np.pi))
         self.assertTrue(np.isclose(bearing(0, 0, -0.1, -0.1), -3 / 4 * np.pi))
-        self.assertTrue(np.isclose(bearing(0, 0, 0, -0.1), -np.pi / 2))
-        self.assertTrue(np.isclose(bearing(0, 0, 0.1, -0.1), -np.pi / 4))
+        self.assertTrue(np.isclose(bearing(0, 0, -0.1, 0), -np.pi / 2))
+        self.assertTrue(np.isclose(bearing(0, 0, -0.1, 0.1), -np.pi / 4))

--- a/tests/haversine_tests.py
+++ b/tests/haversine_tests.py
@@ -27,18 +27,10 @@ class haversine_tests(unittest.TestCase):
         )
 
     def test_distance_antimeridian(self):
-        self.assertTrue(
-            np.isclose(distance(0, 179.5, 0, -179.5), one_degree_meters)
-        )
-        self.assertTrue(
-            np.isclose(distance(0, -179.5, 0, 179.5), one_degree_meters)
-        )
-        self.assertTrue(
-            np.isclose(distance(0, 359.5, 0, 360.5), one_degree_meters)
-        )
-        self.assertTrue(
-            np.isclose(distance(0, 360.5, 0, 359.5), one_degree_meters)
-        )
+        self.assertTrue(np.isclose(distance(0, 179.5, 0, -179.5), one_degree_meters))
+        self.assertTrue(np.isclose(distance(0, -179.5, 0, 179.5), one_degree_meters))
+        self.assertTrue(np.isclose(distance(0, 359.5, 0, 360.5), one_degree_meters))
+        self.assertTrue(np.isclose(distance(0, 360.5, 0, 359.5), one_degree_meters))
 
     def test_bearing(self):
         self.assertTrue(np.isclose(bearing(0, 0, 0, 0.1), 0))

--- a/tests/haversine_tests.py
+++ b/tests/haversine_tests.py
@@ -1,0 +1,39 @@
+from clouddrift.haversine import distance, bearing, EARTH_RADIUS_METERS
+import unittest
+import numpy as np
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+one_degree_meters = 2 * np.pi * EARTH_RADIUS_METERS / 360
+
+class haversine_tests(unittest.TestCase):
+
+    def test_distance_one_degree(self):
+        self.assertTrue(np.isclose(distance(0, 0, 0, 1), one_degree_meters)) 
+        self.assertTrue(np.isclose(distance(0, 0, 1, 0), one_degree_meters)) 
+        self.assertTrue(np.isclose(distance(0, 0, 0, -1), one_degree_meters)) 
+        self.assertTrue(np.isclose(distance(0, 0, -1, 0), one_degree_meters)) 
+    
+    def test_distance_arraylike(self):
+        self.assertTrue(np.all(np.isclose(
+            distance([0, 0], [0, 0], [0, 0], [1, 1]),
+            np.array(2 * [one_degree_meters])
+        )))
+
+    def test_distance_antimeridian(self):
+        self.assertTrue(np.isclose(distance(0, 179.5, 0, -179.5), one_degree_meters)) 
+        self.assertTrue(np.isclose(distance(0, -179.5, 0, 179.5), one_degree_meters)) 
+        self.assertTrue(np.isclose(distance(0, 359.5, 0, 360.5), one_degree_meters)) 
+        self.assertTrue(np.isclose(distance(0, 360.5, 0, 359.5), one_degree_meters)) 
+
+    def test_bearing(self):
+        self.assertTrue(np.isclose(bearing(0, 0, 0.1, 0), 0))
+        self.assertTrue(np.isclose(bearing(0, 0, 0.1, 0.1), np.pi / 4))
+        self.assertTrue(np.isclose(bearing(0, 0, 0, 0.1), np.pi / 2))
+        self.assertTrue(np.isclose(bearing(0, 0, -0.1, 0.1), 3 / 4 * np.pi))
+        self.assertTrue(np.isclose(bearing(0, 0, -0.1, 0), np.pi))
+        self.assertTrue(np.isclose(bearing(0, 0, -0.1, -0.1), - 3 / 4 * np.pi))
+        self.assertTrue(np.isclose(bearing(0, 0, 0, -0.1), - np.pi / 2))
+        self.assertTrue(np.isclose(bearing(0, 0, 0.1, -0.1), - np.pi / 4))


### PR DESCRIPTION
This PR implements the `velocity_from_positions` that returns Cartesian (u, v) velocity from arrays of Cartesian (easting, northing) or spherical (lon, lat) positions.

* [x] Implementation
  * [x] Haversine distance and bearing
  * [x] velocity_from_positions 
* [x] Tests:
  - [x] Haversine tests
  - [x] velocity_from_positions tests
* [x] Docstrings

I considered using the [haversine](https://github.com/mapado/haversine) package as a dependency because it implements the distance function. However, considering that it doesn't implement the Haversine bearing, I decided to not add it as a dependency and implement a subset of functionality that we need directly in this package in the `clouddrift.haversine` module.

Using the Haversine bearing to compute Cartesian dx, dy is limited because it assumes a plane rather than a sphere. For a dlon, dlat of ~0.1 degree, the accuracy is about 1e-5 rad. The accuracy decreases with dlon and dlat. Any feedback on how to improve this is very welcome.

Closes #62.