### PR TITLE
Allow specifying `time_axis` in `velocity_from_position`

### DIFF
--- a/clouddrift/analysis.py
+++ b/clouddrift/analysis.py
@@ -72,19 +72,18 @@ def velocity_from_position(
             f"time_axis ({time_axis}) is outside of the valid range ([-1, {len(x.shape) - 1}])."
         )
 
-    # If time_axis is not the last one, reshape the inputs
+    # Nominal order of axes on input, i.e. (0, 1, 2, ..., N-1)
+    target_axes = list(range(len(x.shape)))
+
+    # If time_axis is not the last one, transpose the inputs
     if time_axis != -1 and time_axis < len(x.shape) - 1:
-        target_shape = list(x.shape)
-        num_time = target_shape.pop(time_axis)
-        target_shape.append(num_time)
-        target_shape = tuple(target_shape)
-    else:
-        target_shape = x.shape
+        target_axes.pop(target_axes.index(time_axis))
+        target_axes.append(time_axis)
 
     # Reshape the inputs to ensure the time axis is last (fast-varying)
-    x_ = np.reshape(x, target_shape)
-    y_ = np.reshape(y, target_shape)
-    time_ = np.reshape(time, target_shape)
+    x_ = np.transpose(x, target_axes)
+    y_ = np.transpose(y, target_axes)
+    time_ = np.transpose(time, target_axes)
 
     dx = np.empty(x_.shape)
     dy = np.empty(y_.shape)
@@ -198,7 +197,7 @@ def velocity_from_position(
             'difference_scheme must be "forward", "backward", or "centered".'
         )
 
-    if target_shape == x.shape:
+    if target_axes == list(range(len(x.shape))):
         return dx / dt, dy / dt
     else:
-        return np.reshape(dx / dt, x.shape), np.reshape(dy / dt, y.shape)
+        return np.transpose(dx / dt, target_axes), np.transpose(dy / dt, target_axes)

--- a/clouddrift/analysis.py
+++ b/clouddrift/analysis.py
@@ -77,8 +77,7 @@ def velocity_from_position(
 
     # If time_axis is not the last one, transpose the inputs
     if time_axis != -1 and time_axis < len(x.shape) - 1:
-        target_axes.pop(target_axes.index(time_axis))
-        target_axes.append(time_axis)
+        target_axes.append(target_axes.pop(target_axes.index(time_axis)))
 
     # Reshape the inputs to ensure the time axis is last (fast-varying)
     x_ = np.transpose(x, target_axes)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clouddrift"
-version = "0.4.0"
+version = "0.5.0"
 authors = [
   { name="Shane Elipot", email="selipot@miami.edu" },
   { name="Philippe Miron", email="philippemiron@gmail.com" },

--- a/tests/analysis_tests.py
+++ b/tests/analysis_tests.py
@@ -75,11 +75,21 @@ class velocity_from_position_tests(unittest.TestCase):
         self.assertTrue(np.all(vf.shape == expected_vf.shape))
 
     def test_time_axis(self):
-        lon = np.reshape(np.tile(self.lon, 4), (2, self.lon.size, 2))
-        lat = np.reshape(np.tile(self.lat, 4), (2, self.lat.size, 2))
-        time = np.reshape(np.tile(self.time, 4), (2, self.time.size, 2))
-        expected_uf = np.reshape(np.tile(self.uf, 4), (2, self.uf.size, 2))
-        expected_vf = np.reshape(np.tile(self.vf, 4), (2, self.vf.size, 2))
+        lon = np.transpose(
+            np.reshape(np.tile(self.lon, 4), (2, 2, self.lon.size)), (0, 2, 1)
+        )
+        lat = np.transpose(
+            np.reshape(np.tile(self.lat, 4), (2, 2, self.lat.size)), (0, 2, 1)
+        )
+        time = np.transpose(
+            np.reshape(np.tile(self.time, 4), (2, 2, self.time.size)), (0, 2, 1)
+        )
+        expected_uf = np.transpose(
+            np.reshape(np.tile(self.uf, 4), (2, 2, self.uf.size)), (0, 2, 1)
+        )
+        expected_vf = np.transpose(
+            np.reshape(np.tile(self.vf, 4), (2, 2, self.vf.size)), (0, 2, 1)
+        )
         uf, vf = velocity_from_position(lon, lat, time, time_axis=1)
         self.assertTrue(np.all(uf == expected_uf))
         self.assertTrue(np.all(vf == expected_vf))

--- a/tests/analysis_tests.py
+++ b/tests/analysis_tests.py
@@ -73,3 +73,15 @@ class velocity_from_position_tests(unittest.TestCase):
         self.assertTrue(np.all(vf == expected_vf))
         self.assertTrue(np.all(uf.shape == expected_uf.shape))
         self.assertTrue(np.all(vf.shape == expected_vf.shape))
+
+    def test_time_axis(self):
+        lon = np.reshape(np.tile(self.lon, 4), (2, self.lon.size, 2))
+        lat = np.reshape(np.tile(self.lat, 4), (2, self.lat.size, 2))
+        time = np.reshape(np.tile(self.time, 4), (2, self.time.size, 2))
+        expected_uf = np.reshape(np.tile(self.uf, 4), (2, self.uf.size, 2))
+        expected_vf = np.reshape(np.tile(self.vf, 4), (2, self.vf.size, 2))
+        uf, vf = velocity_from_position(lon, lat, time, time_axis=1)
+        self.assertTrue(np.all(uf == expected_uf))
+        self.assertTrue(np.all(vf == expected_vf))
+        self.assertTrue(np.all(uf.shape == expected_uf.shape))
+        self.assertTrue(np.all(vf.shape == expected_vf.shape))


### PR DESCRIPTION
This PR implements #73.

It took some trial and error to get right. Multidimensional stuff getting reshaped and reordered can give me a headache, but I think the current implementation works, based on one test with 3-d input arrays where the time axis is the one in the middle, and based on my playing interactively with a few GLAD trajectories.

The implementation is, in a nutshell:

1. `time_axis` is -1 (last) if not present
2. If `time_axis` is present and different from -1 or `size(x.shape) - 1`, transpose the input arrays (into new copies, of course) so that the new time axis is last; the rest of the algorithm is the same as before
3. If inputs were transposed, transpose back so that the output velocities have the same shape as inputs.

With this PR merged, let's release 0.5.0 as long as we don't discover other problems with the function in the meantime.

Closes #73.