### PR TITLE
Unbump to v0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clouddrift"
-version = "0.5.0"
+version = "0.4.0"
 authors = [
   { name="Shane Elipot", email="selipot@miami.edu" },
   { name="Philippe Miron", email="philippemiron@gmail.com" },


### PR DESCRIPTION
I bumped to v0.5.0 by mistake in #73, but the next minor version should be 0.4.0.