### PR TITLE
Refactor coordinates

### DIFF
--- a/clouddrift/dataformat.py
+++ b/clouddrift/dataformat.py
@@ -27,7 +27,7 @@ class RaggedArray:
     def from_awkward(
         cls,
         array: ak.Array,
-        name_coords: Optional[list] = ["time", "lon", "lat", "ids"],
+        vars_coords: Optional[list] = ["time", "lon", "lat", "ids"],
     ):
         """Load a RaggedArray instance from an Awkward Array.
 
@@ -112,7 +112,7 @@ class RaggedArray:
 
     @classmethod
     def from_parquet(
-        cls, filename: str, name_coords: Optional[list] = ["time", "lon", "lat", "ids"]
+        cls, filename: str, vars_coords: Optional[list] = ["time", "lon", "lat", "ids"]
     ):
         """Read a ragged arrays archive from a parquet file
 
@@ -123,7 +123,7 @@ class RaggedArray:
         Returns:
             obj: ragged array class object
         """
-        return cls.from_awkward(ak.from_parquet(filename), name_coords)
+        return cls.from_awkward(ak.from_parquet(filename), vars_coords)
 
     @classmethod
     def from_xarray(cls, ds: xr.Dataset, dim_traj: str = "traj", dim_obs: str = "obs"):

--- a/clouddrift/dataformat.py
+++ b/clouddrift/dataformat.py
@@ -194,6 +194,17 @@ class RaggedArray:
     def attributes(
         ds: xr.Dataset, name_coords: list, name_meta: list, name_data: list
     ) -> Tuple[dict, dict]:
+        """Returns the global attributes and the attributes of all variables (name_coords, name_meta, and name_data) from a xr.Dataset
+
+        Args:
+            ds (xr.Dataset): _description_
+            name_coords (list): Name of the coordinate variables to include in the archive
+            name_meta (list): Name of metadata variables to include in the archive (Defaults to [])
+            name_data (list): Name of the data variables to include in the archive (Defaults to [])
+
+        Returns:
+            Tuple[dict, dict]: the global and variables attributes
+        """
         attrs_global = ds.attrs
 
         # coordinates, metadata, and data

--- a/clouddrift/dataformat.py
+++ b/clouddrift/dataformat.py
@@ -199,8 +199,8 @@ class RaggedArray:
         attrs_variables = {}
 
         # coordinates
-        for var in vars_coords.keys():
-            attrs_variables[var] = ds[vars_coords[var]].attrs
+        for var in vars_coords:
+            attrs_variables[var] = ds[var].attrs
 
         # metadata and data
         for var in vars_meta + vars_data:
@@ -213,7 +213,7 @@ class RaggedArray:
         preprocess_func: Callable[[int], xr.Dataset],
         indices: list,
         rowsize: list,
-        vars_coords: dict,
+        vars_coords: list,
         vars_meta: list,
         vars_data: list,
     ) -> Tuple[dict, dict, dict]:

--- a/clouddrift/dataformat.py
+++ b/clouddrift/dataformat.py
@@ -213,9 +213,9 @@ class RaggedArray:
         preprocess_func: Callable[[int], xr.Dataset],
         indices: list,
         rowsize: list,
-        vars_coords: list,
-        vars_meta: list,
-        vars_data: list,
+        name_coords: list,
+        name_meta: list,
+        name_data: list,
     ) -> Tuple[dict, dict, dict]:
         """Iterate through the files and fill for the ragged array associated with coordinates, and selected metadata and data variables.
 

--- a/clouddrift/dataformat.py
+++ b/clouddrift/dataformat.py
@@ -27,7 +27,7 @@ class RaggedArray:
     def from_awkward(
         cls,
         array: ak.Array,
-        vars_coords: Optional[list] = ["time", "lon", "lat", "ids"],
+        name_coords: Optional[list] = ["time", "lon", "lat", "ids"],
     ):
         """Load a RaggedArray instance from an Awkward Array.
 
@@ -45,7 +45,7 @@ class RaggedArray:
 
         attrs_global = array.layout.parameters["attrs"]
 
-        for var in vars_coords:
+        for var in name_coords:
             coords[var] = ak.flatten(array.obs[var]).to_numpy()
             attrs_variables[var] = array.obs[var].layout.parameters["attrs"]
 
@@ -53,7 +53,7 @@ class RaggedArray:
             metadata[var] = array[var].to_numpy()
             attrs_variables[var] = array[var].layout.parameters["attrs"]
 
-        for var in [v for v in array.obs.fields if v not in vars_coords]:
+        for var in [v for v in array.obs.fields if v not in name_coords]:
             data[var] = ak.flatten(array.obs[var]).to_numpy()
             attrs_variables[var] = array.obs[var].layout.parameters["attrs"]
 
@@ -64,9 +64,9 @@ class RaggedArray:
         cls,
         indices: list,
         preprocess_func: Callable[[int], xr.Dataset],
-        vars_coords: list,
-        vars_meta: Optional[list] = [],
-        vars_data: Optional[list] = [],
+        name_coords: list,
+        name_meta: Optional[list] = [],
+        name_data: Optional[list] = [],
         rowsize_func: Optional[Callable[[int], int]] = None,
     ):
         """Generate ragged arrays archive from a list of trajectory files
@@ -74,9 +74,9 @@ class RaggedArray:
         Args:
             indices (list): identification numbers list to iterate
             preprocess_func (Callable[[int], xr.Dataset]): returns a processed xarray Dataset from an identification number
-            vars_coords (list): coordinate variable names to include in the archive
-            vars_meta (list, optional): metadata variable names to include in the archive (Defaults to [])
-            vars_data (list, optional): data variable names to include in the archive (Defaults to [])
+            name_coords (list): Name of the coordinate variables to include in the archive
+            name_meta (list, optional): Name of metadata variables to include in the archive (Defaults to [])
+            name_data (list, optional): Name of the data variables to include in the archive (Defaults to [])
             rowsize_func (Optional[Callable[[int], int]], optional): returns the number of observations from an identification number (to speed up processing) (Defaults to None)
 
         Returns:
@@ -88,10 +88,10 @@ class RaggedArray:
         )
         rowsize = cls.number_of_observations(rowsize_func, indices)
         coords, metadata, data = cls.allocate(
-            preprocess_func, indices, rowsize, vars_coords, vars_meta, vars_data
+            preprocess_func, indices, rowsize, name_coords, name_meta, name_data
         )
         attrs_global, attrs_variables = cls.attributes(
-            preprocess_func(indices[0]), vars_coords, vars_meta, vars_data
+            preprocess_func(indices[0]), name_coords, name_meta, name_data
         )
 
         return cls(coords, metadata, data, attrs_global, attrs_variables)
@@ -112,7 +112,7 @@ class RaggedArray:
 
     @classmethod
     def from_parquet(
-        cls, filename: str, vars_coords: Optional[list] = ["time", "lon", "lat", "ids"]
+        cls, filename: str, name_coords: Optional[list] = ["time", "lon", "lat", "ids"]
     ):
         """Read a ragged arrays archive from a parquet file
 
@@ -123,7 +123,7 @@ class RaggedArray:
         Returns:
             obj: ragged array class object
         """
-        return cls.from_awkward(ak.from_parquet(filename), vars_coords)
+        return cls.from_awkward(ak.from_parquet(filename), name_coords)
 
     @classmethod
     def from_xarray(cls, ds: xr.Dataset, dim_traj: str = "traj", dim_obs: str = "obs"):
@@ -192,7 +192,7 @@ class RaggedArray:
 
     @staticmethod
     def attributes(
-        ds: xr.Dataset, vars_coords: dict, vars_meta: list, vars_data: list
+        ds: xr.Dataset, name_coords: list, name_meta: list, name_data: list
     ) -> Tuple[dict, dict]:
         attrs_global = ds.attrs
 
@@ -223,9 +223,9 @@ class RaggedArray:
             preprocess_func (Callable[[int], xr.Dataset]): returns a processed xarray Dataset from an identification number
             indices (list): list of indices separating trajectory in the ragged arrays
             rowsize (list): list of the number of observations per trajectory
-            vars_coords (dict): Dictionary mapping field dimensions (ids, time, lon, lat)
-            vars_meta (list): metadata variable names to include in the archive (Defaults to [])
-            vars_data (list): data variable names to include in the archive (Defaults to [])
+            name_coords (list): Name of the coordinate variables to include in the archive
+            name_meta (list, optional): Name of metadata variables to include in the archive (Defaults to [])
+            name_data (list, optional): Name of the data variables to include in the archive (Defaults to [])
 
         Returns:
             Tuple[dict, dict, dict]: dictionaries containing numerical data and attributes of coordinates, metadata and data variables.
@@ -239,15 +239,15 @@ class RaggedArray:
 
         # allocate memory
         coords = {}
-        for var in vars_coords:
+        for var in name_coords:
             coords[var] = np.zeros(nb_obs, dtype=ds[var].dtype)
 
         metadata = {}
-        for var in vars_meta:
+        for var in name_meta:
             metadata[var] = np.zeros(nb_traj, dtype=ds[var].dtype)
 
         data = {}
-        for var in vars_data:
+        for var in name_data:
             data[var] = np.zeros(nb_obs, dtype=ds[var].dtype)
         ds.close()
 
@@ -262,13 +262,13 @@ class RaggedArray:
                 size = rowsize[i]
                 oid = index_traj[i]
 
-                for var in vars_coords:
+                for var in name_coords:
                     coords[var][oid : oid + size] = ds[var].data
 
-                for var in vars_meta:
+                for var in name_meta:
                     metadata[var][i] = ds[var][0].data
 
-                for var in vars_data:
+                for var in name_data:
                     data[var][oid : oid + size] = ds[var].data
 
         return coords, metadata, data

--- a/clouddrift/dataformat.py
+++ b/clouddrift/dataformat.py
@@ -45,7 +45,7 @@ class RaggedArray:
 
         attrs_global = array.layout.parameters["attrs"]
 
-        for var in name_coords:
+        for var in vars_coords:
             coords[var] = ak.flatten(array.obs[var]).to_numpy()
             attrs_variables[var] = array.obs[var].layout.parameters["attrs"]
 
@@ -53,7 +53,7 @@ class RaggedArray:
             metadata[var] = array[var].to_numpy()
             attrs_variables[var] = array[var].layout.parameters["attrs"]
 
-        for var in [v for v in array.obs.fields if v not in name_coords]:
+        for var in [v for v in array.obs.fields if v not in vars_coords]:
             data[var] = ak.flatten(array.obs[var]).to_numpy()
             attrs_variables[var] = array.obs[var].layout.parameters["attrs"]
 

--- a/clouddrift/dataformat.py
+++ b/clouddrift/dataformat.py
@@ -60,9 +60,9 @@ class RaggedArray:
         cls,
         indices: list,
         preprocess_func: Callable[[int], xr.Dataset],
-        vars_coords: dict,
-        vars_meta: list = [],
-        vars_data: list = [],
+        vars_coords: list,
+        vars_meta: Optional[list] = [],
+        vars_data: Optional[list] = [],
         rowsize_func: Optional[Callable[[int], int]] = None,
     ):
         """Generate ragged arrays archive from a list of trajectory files
@@ -70,7 +70,7 @@ class RaggedArray:
         Args:
             indices (list): identification numbers list to iterate
             preprocess_func (Callable[[int], xr.Dataset]): returns a processed xarray Dataset from an identification number
-            vars_coords (dict): Dictionary mapping field dimensions (ids, time, lon, lat)
+            vars_coords (list): coordinate variable names to include in the archive
             vars_meta (list, optional): metadata variable names to include in the archive (Defaults to [])
             vars_data (list, optional): data variable names to include in the archive (Defaults to [])
             rowsize_func (Optional[Callable[[int], int]], optional): returns a processed xarray Dataset from an identification number (to speed up processing) (Defaults to None)
@@ -232,8 +232,8 @@ class RaggedArray:
 
         # allocate memory
         coords = {}
-        for var in vars_coords.keys():
-            coords[var] = np.zeros(nb_obs, dtype=ds[vars_coords[var]].dtype)
+        for var in vars_coords:
+            coords[var] = np.zeros(nb_obs, dtype=ds[var].dtype)
 
         metadata = {}
         for var in vars_meta:
@@ -255,8 +255,8 @@ class RaggedArray:
                 size = rowsize[i]
                 oid = index_traj[i]
 
-                for var in vars_coords.keys():
-                    coords[var][oid : oid + size] = ds[vars_coords[var]].data
+                for var in vars_coords:
+                    coords[var][oid : oid + size] = ds[var].data
 
                 for var in vars_meta:
                     metadata[var][i] = ds[var][0].data

--- a/clouddrift/dataformat.py
+++ b/clouddrift/dataformat.py
@@ -196,14 +196,9 @@ class RaggedArray:
     ) -> Tuple[dict, dict]:
         attrs_global = ds.attrs
 
+        # coordinates, metadata, and data
         attrs_variables = {}
-
-        # coordinates
-        for var in vars_coords:
-            attrs_variables[var] = ds[var].attrs
-
-        # metadata and data
-        for var in vars_meta + vars_data:
+        for var in name_coords + name_meta + name_data:
             attrs_variables[var] = ds[var].attrs
 
         return attrs_global, attrs_variables

--- a/clouddrift/dataformat.py
+++ b/clouddrift/dataformat.py
@@ -24,11 +24,16 @@ class RaggedArray:
         self.validate_attributes()
 
     @classmethod
-    def from_awkward(cls, array: ak.Array):
+    def from_awkward(
+        cls,
+        array: ak.Array,
+        name_coords: Optional[list] = ["time", "lon", "lat", "ids"],
+    ):
         """Load a RaggedArray instance from an Awkward Array.
 
         Args:
             array (ak.Array): Awkward Array instance to load the data from
+            name_coords (list, optional): Names of the coordinate variables in the ragged arrays
 
         Returns:
             obj: RaggedArray instance
@@ -40,7 +45,6 @@ class RaggedArray:
 
         attrs_global = array.layout.parameters["attrs"]
 
-        name_coords = ["time", "lon", "lat", "ids"]
         for var in name_coords:
             coords[var] = ak.flatten(array.obs[var]).to_numpy()
             attrs_variables[var] = array.obs[var].layout.parameters["attrs"]
@@ -107,16 +111,19 @@ class RaggedArray:
         return cls.from_xarray(xr.open_dataset(filename))
 
     @classmethod
-    def from_parquet(cls, filename: str):
+    def from_parquet(
+        cls, filename: str, name_coords: Optional[list] = ["time", "lon", "lat", "ids"]
+    ):
         """Read a ragged arrays archive from a parquet file
 
         Args:
             filename (str): filename of parquet archive
+            name_coords (list, optional): Names of the coordinate variables in the ragged arrays
 
         Returns:
             obj: ragged array class object
         """
-        return cls.from_awkward(ak.from_parquet(filename))
+        return cls.from_awkward(ak.from_parquet(filename), name_coords)
 
     @classmethod
     def from_xarray(cls, ds: xr.Dataset, dim_traj: str = "traj", dim_obs: str = "obs"):

--- a/clouddrift/dataformat.py
+++ b/clouddrift/dataformat.py
@@ -77,7 +77,7 @@ class RaggedArray:
             vars_coords (list): coordinate variable names to include in the archive
             vars_meta (list, optional): metadata variable names to include in the archive (Defaults to [])
             vars_data (list, optional): data variable names to include in the archive (Defaults to [])
-            rowsize_func (Optional[Callable[[int], int]], optional): returns a processed xarray Dataset from an identification number (to speed up processing) (Defaults to None)
+            rowsize_func (Optional[Callable[[int], int]], optional): returns the number of observations from an identification number (to speed up processing) (Defaults to None)
 
         Returns:
             obj: ragged array class object

--- a/tests/dataformat_tests.py
+++ b/tests/dataformat_tests.py
@@ -109,19 +109,12 @@ class dataformat_tests(TestCase):
         self.assertEqual(len(self.ra.metadata["ID"]), self.nb_traj)
         self.assertEqual(len(self.ra.data["temp"]), self.nb_obs)
 
-    def test_rename_coords(self):
-        """
-        Validate that coordinates name were modified
-        """
-        for key in self.ra.coords:
-            self.assertTrue(key in ("ids", "lon", "lat", "time"))
-
     def test_variable_attrs(self):
         """
         Validate the variable attributes are properly transferred to the ragged array object.
         Note: as part of this test `long_name` is variable but `units` are always "-"
         """
-        for var in ["lon", "lat", "time"]:  # coords are rename but not attributes here
+        for var in ["lon", "lat", "time"]:
             self.assertEqual(
                 self.ra.attrs_variables[var]["long_name"],
                 f"variable {var}",

--- a/tests/dataformat_tests.py
+++ b/tests/dataformat_tests.py
@@ -26,18 +26,13 @@ class dataformat_tests(TestCase):
             "title": "test trajectories",
             "history": "version xyz",
         }
-        self.variables_coords = {
-            "ids": "ids",
-            "time": "t",
-            "lon": "longitude",
-            "lat": "latitude",
-        }
+        self.variables_coords = ["ids", "time", "lon", "lat"]
 
         # append xr.Dataset to a list
         list_ds = []
         for i in range(0, len(self.rowsize)):
             xr_coords = {}
-            for var in ["longitude", "latitude", "t"]:
+            for var in ["lon", "lat", "time"]:
                 xr_coords[var] = (
                     ["obs"],
                     np.random.rand(self.rowsize[i]),
@@ -129,7 +124,7 @@ class dataformat_tests(TestCase):
         for var in ["lon", "lat", "time"]:  # coords are rename but not attributes here
             self.assertEqual(
                 self.ra.attrs_variables[var]["long_name"],
-                f"variable {self.variables_coords[var]}",
+                f"variable {var}",
             )
             self.assertEqual(self.ra.attrs_variables[var]["units"], "-")
 

--- a/tests/select_tests.py
+++ b/tests/select_tests.py
@@ -38,13 +38,9 @@ class select_tests(TestCase):
             "title": "test trajectories",
             "history": "version xyz",
         }
-        variables_coords = {
-            "ids": "ids",
-            "time": "t",
-            "lon": "longitude",
-            "lat": "latitude",
-        }
-        coords = {"longitude": longitude, "latitude": latitude, "ids": ids, "t": t}
+        variables_coords = ["ids", "time", "lon", "lat"]
+
+        coords = {"lon": longitude, "lat": latitude, "ids": ids, "time": t}
         metadata = {"ID": drifter_id, "rowsize": rowsize}
         data = {"test": test}
 


### PR DESCRIPTION
Implemented #82 and what was discussed here https://github.com/Cloud-Drift/clouddrift-examples/issues/18.

The main API difference is with the RaggedArray.from_files().
```
def from_files(
        cls,
        indices: list,
        preprocess_func: Callable[[int], xr.Dataset],
        **vars_coords: list**,
        vars_meta: Optional[list] = [],
        vars_data: Optional[list] = [],
        rowsize_func: Optional[Callable[[int], int]] = None,
    ):
```
Above are the new parameters. The coordinates are now passed as a simple list. The pros and cons of this are:
- \+ more streamline with the other arguments, `coords`, `metadata`, `data` are now all lists.
- \+ a user can easily add/remove variables to the coordinates list. They don't have to be set as coordinates in `xarray` by the preprocessing functions anymore.
- \+ not assuming any number of coordinate variables.
- \- we can't rename the coordinates at this point. 
- \+ we can't rename the coordinates at this point (😀); I now think that might have been a bit confusing. Now, if you want to modify anything in the original dataset (like the coordinate names, attributes, etc.), it is all done in the `preprocess_func`.

As I said, we are not assuming that the coordinates in a previously constructed ragged array are `["ids", "lon", "lat", "time"]`. For the functions related to `xarray` (`from_xarray()`, `from_netcdf()`), this has no effect since any variables identified as a coordinate will be found in `ds.coords.keys()` and handled properly. However, there is no concept of *coordinates* in a parquet file, so this requires adding a `vars_coords` parameter to properly retrieve all coordinate variables in Awkward related functions (`from_awkward` and `from_parquet()`).

PS: I can take care to update `clouddrift-examples` afterward.