### PR TITLE
`gdp.to_raggedarray`

### DIFF
--- a/clouddrift/adapters/gdp.py
+++ b/clouddrift/adapters/gdp.py
@@ -17,6 +17,72 @@ GDP_DATA_URL = "https://www.aoml.noaa.gov/ftp/pub/phod/lumpkin/hourly/v2.00/netc
 GDP_FILENAME_PATTERN = "drifter_{id}.nc"
 GDP_TMP_PATH = os.path.join(tempfile.gettempdir(), "clouddrift", "gdp")
 
+GDP_COORDS = [
+    "ids",
+    "time",
+]
+GDP_METADATA = [
+    "ID",
+    "rowsize",
+    "WMO",
+    "expno",
+    "deploy_date",
+    "deploy_lat",
+    "deploy_lon",
+    "end_date",
+    "end_lat",
+    "end_lon",
+    "drogue_lost_date",
+    "typedeath",
+    "typebuoy",
+    "location_type",
+    "DeployingShip",
+    "DeploymentStatus",
+    "BuoyTypeManufacturer",
+    "BuoyTypeSensorArray",
+    "CurrentProgram",
+    "PurchaserFunding",
+    "SensorUpgrade",
+    "Transmissions",
+    "DeployingCountry",
+    "DeploymentComments",
+    "ManufactureYear",
+    "ManufactureMonth",
+    "ManufactureSensorType",
+    "ManufactureVoltage",
+    "FloatDiameter",
+    "SubsfcFloatPresence",
+    "DrogueType",
+    "DrogueLength",
+    "DrogueBallast",
+    "DragAreaAboveDrogue",
+    "DragAreaOfDrogue",
+    "DragAreaRatio",
+    "DrogueCenterDepth",
+    "DrogueDetectSensor",
+]
+GDP_DATA = [
+    "lon",
+    "lat",
+    "ve",
+    "vn",
+    "err_lat",
+    "err_lon",
+    "err_ve",
+    "err_vn",
+    "gap",
+    "sst",
+    "sst1",
+    "sst2",
+    "err_sst",
+    "err_sst1",
+    "err_sst2",
+    "flg_sst",
+    "flg_sst1",
+    "flg_sst2",
+    "drogue_status",
+]
+
 
 def parse_directory_file(filename: str) -> pd.DataFrame:
     """Read a directory file which contains metadata of drifters' releases.
@@ -550,83 +616,26 @@ def preprocess(index: int) -> xr.Dataset:
     return ds
 
 
-def to_raggedarray(drifter_ids: Optional[list[int]] = None) -> RaggedArray:
+def to_raggedarray(
+    drifter_ids: Optional[list[int]] = None, n_random_id: Optional[int] = None
+) -> RaggedArray:
     """Download and process individual GDP hourly files and return a
     RaggedArray instance with the data.
-    """
-    coords = {
-        "ids": "ids",
-        "time": "time",
-        "lon": "longitude",  # or alternatively lon360
-        "lat": "latitude",
-    }
-    metadata = [
-        "ID",
-        "rowsize",
-        "WMO",
-        "expno",
-        "deploy_date",
-        "deploy_lat",
-        "deploy_lon",
-        "end_date",
-        "end_lat",
-        "end_lon",
-        "drogue_lost_date",
-        "typedeath",
-        "typebuoy",
-        "location_type",
-        "DeployingShip",
-        "DeploymentStatus",
-        "BuoyTypeManufacturer",
-        "BuoyTypeSensorArray",
-        "CurrentProgram",
-        "PurchaserFunding",
-        "SensorUpgrade",
-        "Transmissions",
-        "DeployingCountry",
-        "DeploymentComments",
-        "ManufactureYear",
-        "ManufactureMonth",
-        "ManufactureSensorType",
-        "ManufactureVoltage",
-        "FloatDiameter",
-        "SubsfcFloatPresence",
-        "DrogueType",
-        "DrogueLength",
-        "DrogueBallast",
-        "DragAreaAboveDrogue",
-        "DragAreaOfDrogue",
-        "DragAreaRatio",
-        "DrogueCenterDepth",
-        "DrogueDetectSensor",
-    ]
-    data = [
-        "ve",
-        "vn",
-        "err_lat",
-        "err_lon",
-        "err_ve",
-        "err_vn",
-        "gap",
-        "sst",
-        "sst1",
-        "sst2",
-        "err_sst",
-        "err_sst1",
-        "err_sst2",
-        "flg_sst",
-        "flg_sst1",
-        "flg_sst2",
-        "drogue_status",
-    ]
 
-    drifter_ids = download()
+    Args:
+        drifter_ids [list]: list of drifters to retrieve (Default: all)
+        n_random_id [int]: randomly select n drifter NetCDF files
+    Returns:
+        out [RaggedArray]: A RaggedArray instance of the requested dataset
+    """
+
+    ids = download(drifter_ids, n_random_id)
 
     return RaggedArray.from_files(
-        drifter_ids,
+        indices=ids,
         preprocess_func=preprocess,
-        name_coords=coords,
-        name_meta=metadata,
-        name_data=data,
+        name_coords=GDP_COORDS,
+        name_meta=GDP_METADATA,
+        name_data=GDP_DATA,
         rowsize_func=rowsize,
     )

--- a/clouddrift/adapters/gdp.py
+++ b/clouddrift/adapters/gdp.py
@@ -1,3 +1,4 @@
+from ..dataformat import RaggedArray
 import numpy as np
 import pandas as pd
 from datetime import datetime
@@ -7,6 +8,7 @@ import concurrent.futures
 import re
 import tempfile
 from tqdm import tqdm
+from typing import Optional
 import os
 import warnings
 
@@ -546,3 +548,85 @@ def preprocess(index: int) -> xr.Dataset:
     ds = ds.set_coords(["ids", "longitude", "lon360", "latitude", "time"])
 
     return ds
+
+
+def to_raggedarray(drifter_ids: Optional[list[int]] = None) -> RaggedArray:
+    """Download and process individual GDP hourly files and return a
+    RaggedArray instance with the data.
+    """
+    coords = {
+        "ids": "ids",
+        "time": "time",
+        "lon": "longitude",  # or alternatively lon360
+        "lat": "latitude",
+    }
+    metadata = [
+        "ID",
+        "rowsize",
+        "WMO",
+        "expno",
+        "deploy_date",
+        "deploy_lat",
+        "deploy_lon",
+        "end_date",
+        "end_lat",
+        "end_lon",
+        "drogue_lost_date",
+        "typedeath",
+        "typebuoy",
+        "location_type",
+        "DeployingShip",
+        "DeploymentStatus",
+        "BuoyTypeManufacturer",
+        "BuoyTypeSensorArray",
+        "CurrentProgram",
+        "PurchaserFunding",
+        "SensorUpgrade",
+        "Transmissions",
+        "DeployingCountry",
+        "DeploymentComments",
+        "ManufactureYear",
+        "ManufactureMonth",
+        "ManufactureSensorType",
+        "ManufactureVoltage",
+        "FloatDiameter",
+        "SubsfcFloatPresence",
+        "DrogueType",
+        "DrogueLength",
+        "DrogueBallast",
+        "DragAreaAboveDrogue",
+        "DragAreaOfDrogue",
+        "DragAreaRatio",
+        "DrogueCenterDepth",
+        "DrogueDetectSensor",
+    ]
+    data = [
+        "ve",
+        "vn",
+        "err_lat",
+        "err_lon",
+        "err_ve",
+        "err_vn",
+        "gap",
+        "sst",
+        "sst1",
+        "sst2",
+        "err_sst",
+        "err_sst1",
+        "err_sst2",
+        "flg_sst",
+        "flg_sst1",
+        "flg_sst2",
+        "drogue_status",
+    ]
+
+    drifter_ids = download()
+
+    return RaggedArray.from_files(
+        drifter_ids,
+        preprocess_func=preprocess,
+        name_coords=coords,
+        name_meta=metadata,
+        name_data=data,
+        rowsize_func=rowsize,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clouddrift"
-version = "0.4.0"
+version = "0.5.0"
 authors = [
   { name="Shane Elipot", email="selipot@miami.edu" },
   { name="Philippe Miron", email="philippemiron@gmail.com" },


### PR DESCRIPTION
Implement a function `gdp.to_raggedarray` that is a convenience wrapper of executable code from the GDP hourly example.

`clouddrift.adapters.gdp.to_raggedarray()` can now be used to generate the ragged array NetCDF from hourly individual files.

Also bumped version to 0.5.0.

Not adding this to the Sphinx docs as its not intended for users. Is that reasonable? We can add this module to the API docs if you think it would be useful.