### PR TITLE
Enable GDP experimental

### DIFF
--- a/clouddrift/adapters/gdp.py
+++ b/clouddrift/adapters/gdp.py
@@ -136,13 +136,22 @@ def parse_directory_file(filename: str) -> pd.DataFrame:
 def get_gdp_metadata() -> pd.DataFrame:
     """Download and parse GDP metadata and return it as a Pandas DataFrame."""
 
-    directory_file_names = [
-        "dirfl_1_5000.dat",
-        "dirfl_5001_10000.dat",
-        "dirfl_10001_15000.dat",
-        "dirfl_15001_oct22.dat",
-    ]
-    df = pd.concat([parse_directory_file(f) for f in directory_file_names])
+    directory_file_pattern = "dirfl_{low}_{high}.dat"
+    
+    dfs = []
+    start = 1
+    while True:
+        name = directory_file_pattern.format(low=start, high=start+4999)
+        try:
+            dfs.append(parse_directory_file(name))
+            start += 5000
+        except:
+            break
+    
+    name = directory_file_pattern.format(low=start, high="current")
+    dfs.append(parse_directory_file(name))
+    
+    df = pd.concat(dfs)
     df.sort_values(["Deployment_date"], inplace=True, ignore_index=True)
     return df
 

--- a/clouddrift/adapters/gdp.py
+++ b/clouddrift/adapters/gdp.py
@@ -140,7 +140,7 @@ def get_gdp_metadata() -> pd.DataFrame:
         "dirfl_1_5000.dat",
         "dirfl_5001_10000.dat",
         "dirfl_10001_15000.dat",
-        "dirfl_15001_jul22.dat",
+        "dirfl_15001_oct22.dat",
     ]
     df = pd.concat([parse_directory_file(f) for f in directory_file_names])
     df.sort_values(["Deployment_date"], inplace=True, ignore_index=True)

--- a/clouddrift/adapters/gdp.py
+++ b/clouddrift/adapters/gdp.py
@@ -20,7 +20,7 @@ import warnings
 GDP_VERSION = "2.00"
 GDP_DATA_URL = "https://www.aoml.noaa.gov/ftp/pub/phod/lumpkin/hourly/v2.00/netcdf/"
 GDP_DATA_URL_EXPERIMENTAL = (
-    "ftp://ftp.aoml.noaa.gov/phod/pub/lumpkin/hourly/experimental/"
+    "https://www.aoml.noaa.gov/ftp/pub/phod/lumpkin/hourly/experimental/"
 )
 GDP_TMP_PATH = os.path.join(tempfile.gettempdir(), "clouddrift", "gdp")
 

--- a/clouddrift/adapters/gdp.py
+++ b/clouddrift/adapters/gdp.py
@@ -137,20 +137,20 @@ def get_gdp_metadata() -> pd.DataFrame:
     """Download and parse GDP metadata and return it as a Pandas DataFrame."""
 
     directory_file_pattern = "dirfl_{low}_{high}.dat"
-    
+
     dfs = []
     start = 1
     while True:
-        name = directory_file_pattern.format(low=start, high=start+4999)
+        name = directory_file_pattern.format(low=start, high=start + 4999)
         try:
             dfs.append(parse_directory_file(name))
             start += 5000
         except:
             break
-    
+
     name = directory_file_pattern.format(low=start, high="current")
     dfs.append(parse_directory_file(name))
-    
+
     df = pd.concat(dfs)
     df.sort_values(["Deployment_date"], inplace=True, ignore_index=True)
     return df

--- a/clouddrift/dataformat.py
+++ b/clouddrift/dataformat.py
@@ -86,14 +86,27 @@ class RaggedArray:
         """
         # if no method is supplied, get the dimension from the preprocessing function
         rowsize_func = (
-            rowsize_func if rowsize_func else lambda i, filename_pattern: preprocess_func(i, filename_pattern).dims["obs"]
+            rowsize_func
+            if rowsize_func
+            else lambda i, filename_pattern: preprocess_func(i, filename_pattern).dims[
+                "obs"
+            ]
         )
         rowsize = cls.number_of_observations(rowsize_func, indices, filename_pattern)
         coords, metadata, data = cls.allocate(
-            preprocess_func, indices, filename_pattern, rowsize, name_coords, name_meta, name_data
+            preprocess_func,
+            indices,
+            filename_pattern,
+            rowsize,
+            name_coords,
+            name_meta,
+            name_data,
         )
         attrs_global, attrs_variables = cls.attributes(
-            preprocess_func(indices[0], filename_pattern), name_coords, name_meta, name_data
+            preprocess_func(indices[0], filename_pattern),
+            name_coords,
+            name_meta,
+            name_data,
         )
 
         return cls(coords, metadata, data, attrs_global, attrs_variables)
@@ -289,7 +302,9 @@ class RaggedArray:
                     if var in ds.keys():
                         data[var][oid : oid + size] = ds[var].data
                     else:
-                        warnings.warn(f"Variable {var} requested but not found; skipping.")
+                        warnings.warn(
+                            f"Variable {var} requested but not found; skipping."
+                        )
 
         return coords, metadata, data
 

--- a/clouddrift/dataformat.py
+++ b/clouddrift/dataformat.py
@@ -63,30 +63,30 @@ class RaggedArray:
     def from_files(
         cls,
         indices: list,
-        filename_pattern: str,
         preprocess_func: Callable[[int], xr.Dataset],
         name_coords: list,
         name_meta: Optional[list] = [],
         name_data: Optional[list] = [],
         rowsize_func: Optional[Callable[[int], int]] = None,
+        filename_pattern: Optional[str] = "drifter_{id}.nc",
     ):
         """Generate ragged arrays archive from a list of trajectory files
 
         Args:
             indices (list): identification numbers list to iterate
-            filename_pattern (str): filename pattern as function of id, e.g. 'drifter_{id}.nc'
             preprocess_func (Callable[[int], xr.Dataset]): returns a processed xarray Dataset from an identification number
             name_coords (list): Name of the coordinate variables to include in the archive
             name_meta (list, optional): Name of metadata variables to include in the archive (Defaults to [])
             name_data (list, optional): Name of the data variables to include in the archive (Defaults to [])
             rowsize_func (Optional[Callable[[int], int]], optional): returns the number of observations from an identification number (to speed up processing) (Defaults to None)
+            filename_pattern (Optional[str]): filename pattern as function of id, e.g. 'drifter_{id}.nc' (default), to use as the second argument to preprocess_func and rowsize_func
 
         Returns:
             obj: ragged array class object
         """
         # if no method is supplied, get the dimension from the preprocessing function
         rowsize_func = (
-            rowsize_func if rowsize_func else lambda i: preprocess_func(i, filename_pattern).dims["obs"]
+            rowsize_func if rowsize_func else lambda i, filename_pattern: preprocess_func(i, filename_pattern).dims["obs"]
         )
         rowsize = cls.number_of_observations(rowsize_func, indices, filename_pattern)
         coords, metadata, data = cls.allocate(

--- a/tests/dataformat_tests.py
+++ b/tests/dataformat_tests.py
@@ -68,7 +68,7 @@ class dataformat_tests(TestCase):
         # create test ragged array
         self.ra = RaggedArray.from_files(
             [0, 1, 2],
-            lambda i: list_ds[i],
+            lambda i, _: list_ds[i],
             self.variables_coords,
             ["ID", "rowsize"],
             ["temp"],

--- a/tests/select_tests.py
+++ b/tests/select_tests.py
@@ -77,7 +77,7 @@ class select_tests(TestCase):
         # create test ragged array
         ra = RaggedArray.from_files(
             [0, 1, 2],
-            lambda i: list_ds[i],
+            lambda i, _: list_ds[i],
             variables_coords,
             ["ID", "rowsize"],
             ["test"],


### PR DESCRIPTION
This PR modifies a few things to allow processing GDP experimental data. To do this, I:

* Added an optional `url` parameter to `gdp.to_raggedarray` to allow passing the experimental URL; it otherwise defaults to stable;
* In `gdp.preprocess`, handle missing variables and issue warnings for variables that are missing
* In `RaggedArray.from_files`, `preprocess` and `rowsize` funcs now have a second parameter `filename_pattern`, which was previously a hardcoded global variable in the gdp module. This is now decoupled.  I'm not super happy about this approach, but the alternative is to make a separate module for experimental feed, which to me seems worse.

How to use it:

```python
from clouddrift.adapters.gdp import to_raggedarray, GDP_DATA_URL_EXPERIMENTAL
ra = to_raggedarray(n_random_id=100) # GDP_DATA_URL by default
ra_exp = to_raggedarray(n_random_id=100, url=GDP_DATA_URL_EXPERIMENTAL)
```

Example in action:

```
In [1]: from clouddrift.adapters.gdp import to_raggedarray, GDP_DATA_URL_EXPERIMENTAL

In [2]: ra = to_raggedarray(n_random_id=100) # GDP_DATA_URL by default
Downloading files: 100%|██████████████████████| 100/100 [00:20<00:00,  4.84it/s]
Retrieving the number of obs: 100%|███████████| 100/100 [00:01<00:00, 87.86it/s]
/home/milan/.local/lib/python3.10/site-packages/xarray/coding/variables.py:148: FutureWarning: elementwise comparison failed; returning scalar instead, but in the future will perform elementwise comparison
  condition |= data == fv
Filling the Ragged Array: 100%|███████████████| 100/100 [00:03<00:00, 31.75it/s]
In [3]: ra_exp = to_raggedarray(n_random_id=100, url=GDP_DATA_URL_EXPERIMENTAL)
Downloading files: 100%|██████████████████████| 100/100 [00:11<00:00,  8.43it/s]
Retrieving the number of obs: 100%|████████████| 99/99 [00:00<00:00, 110.63it/s]
/home/milan/Work/clouddrift/clouddrift/clouddrift/adapters/gdp.py:348: UserWarning: Variable sst not found; skipping.
  warnings.warn(f"Variable {var} not found; skipping.")
/home/milan/Work/clouddrift/clouddrift/clouddrift/adapters/gdp.py:348: UserWarning: Variable sst1 not found; skipping.
  warnings.warn(f"Variable {var} not found; skipping.")
/home/milan/Work/clouddrift/clouddrift/clouddrift/adapters/gdp.py:348: UserWarning: Variable sst2 not found; skipping.
  warnings.warn(f"Variable {var} not found; skipping.")
/home/milan/Work/clouddrift/clouddrift/clouddrift/adapters/gdp.py:348: UserWarning: Variable err_sst not found; skipping.
  warnings.warn(f"Variable {var} not found; skipping.")
/home/milan/Work/clouddrift/clouddrift/clouddrift/adapters/gdp.py:348: UserWarning: Variable err_sst1 not found; skipping.
  warnings.warn(f"Variable {var} not found; skipping.")
/home/milan/Work/clouddrift/clouddrift/clouddrift/adapters/gdp.py:348: UserWarning: Variable err_sst2 not found; skipping.
  warnings.warn(f"Variable {var} not found; skipping.")
...
SNIP
In [4]: ds_exp = ra_exp.to_xarray()

In [5]: ds_exp
Out[5]: 
<xarray.Dataset>
Dimensions:                (traj: 99, obs: 929945)
Coordinates:
    ids                    (obs) int64 9505793 9505793 ... 300234065662800
    time                   (obs) float64 8.243e+08 8.243e+08 ... 1.667e+09
Dimensions without coordinates: traj, obs
Data variables: (12/48)
    ID                     (traj) int64 9505793 32431 ... 300234065662800
    rowsize                (traj) int32 10566 15552 11876 ... 4762 2372 3409
    WMO                    (traj) int32 6200507 3100963 ... 6203746 5601562
    expno                  (traj) int32 9435 1195 9325 ... 21312 21321 31312
    deploy_date            (traj) float64 8.243e+08 9.607e+08 ... 1.654e+09
    deploy_lat             (traj) float64 48.22 -25.96 -40.0 ... 66.0 -18.96
    ...                     ...
    err_lat                (obs) float64 2.14e-08 6.82e-08 ... 1.131e-08
    err_lon                (obs) float64 1.129e-07 3.989e-07 ... 1.208e-08
    err_ve                 (obs) float64 0.5218 0.925 ... 0.000854 0.001058
    err_vn                 (obs) float64 0.1318 0.1657 ... 0.000854 0.001058
    gap                    (obs) float64 2.678e+03 3.37e+03 ... 1.797e+04 0.0
    drogue_status          (obs) bool True True True True ... True True True
Attributes: (12/16)
    title:             Global Drifter Program hourly drifting buoy collection
    history:           version 2.00. Metadata from dirall.dat and deplog.dat
    Conventions:       CF-1.6
    date_created:      2023-02-09T18:02:50.433369
    publisher_name:    GDP Drifter DAC
    publisher_email:   aoml.dftr@noaa.gov
    ...                ...
    contributor_name:  NOAA Global Drifter Program
    contributor_role:  Data Acquisition Center
    institution:       NOAA Atlantic Oceanographic and Meteorological Laboratory
    acknowledgement:   Elipot, Shane; Sykulski, Adam; Lumpkin, Rick; Centurio...
    summary:           Global Drifter Program hourly data
    doi:               10.25921/x46c-3620
```