### PR TITLE
Function to unpack a ragged array into a list of regular arrays

### DIFF
--- a/clouddrift/__init__.py
+++ b/clouddrift/__init__.py
@@ -2,7 +2,7 @@ from ._version import version
 
 __version__ = version
 
-from clouddrift.dataformat import RaggedArray
+from clouddrift.dataformat import RaggedArray, unpack_ragged
 import clouddrift.adapters
 import clouddrift.analysis
 import clouddrift.haversine

--- a/clouddrift/dataformat.py
+++ b/clouddrift/dataformat.py
@@ -384,9 +384,9 @@ def unpack_ragged(
 ) -> list[np.ndarray]:
     """Unpack a ragged array into a list of regular arrays.
 
-    Unpacking ragged_array as an np.ndarray is about 2 orders of magnitude
-    faster than unpacking it as an xr.DataArray, so unles you need a DataArray
-    as the result, we recommend passing np.ndarray as input.
+    Unpacking a ``np.ndarray`` ragged array is about 2 orders of magnitude
+    faster than unpacking an ``xr.DataArray`` ragged array, so unless you need a
+    ``DataArray`` as the result, we recommend passing ``np.ndarray`` as input.
 
     Parameters
     ----------

--- a/clouddrift/dataformat.py
+++ b/clouddrift/dataformat.py
@@ -395,5 +395,5 @@ def unpack(ragged_array: np.ndarray, rowsize: np.ndarray[int]) -> list[np.ndarra
             correspond to the values in rowsize, and types that correspond
             to the type of ragged_array
     """
-    indices = np.insert(np.cumsum(ds.rowsize.values), 0, 0)
-    return [ragged_array[indices[n]:indices[n+1]] for n in range(indices.size - 1)]
+    indices = np.insert(np.cumsum(np.array(rowsize)), 0, 0)
+    return [ragged_array[indices[n] : indices[n + 1]] for n in range(indices.size - 1)]

--- a/clouddrift/dataformat.py
+++ b/clouddrift/dataformat.py
@@ -379,21 +379,50 @@ class RaggedArray:
         return
 
 
-def unpack(ragged_array: np.ndarray, rowsize: np.ndarray[int]) -> list[np.ndarray]:
+def unpack_ragged(
+    ragged_array: np.ndarray, rowsize: np.ndarray[int]
+) -> list[np.ndarray]:
     """Unpack a ragged array into a list of regular arrays.
 
     Unpacking ragged_array as an np.ndarray is about 2 orders of magnitude
     faster than unpacking it as an xr.DataArray, so unles you need a DataArray
     as the result, we recommend passing np.ndarray as input.
 
-    Args:
-        ragged_array (array-like): A ragged_array to unpack
-        rowsize (array-like): An array of integers whose values is the size of
-            each row in the ragged array
-    Returns:
-        unpacked_arrays (list): A list of array-likes with sizes that
-            correspond to the values in rowsize, and types that correspond
-            to the type of ragged_array
+    Parameters
+    ----------
+    ragged_array : array-like
+        A ragged_array to unpack
+    rowsize : array-like
+        An array of integers whose values is the size of each row in the ragged
+        array
+
+    Returns
+    -------
+    list
+        A list of array-likes with sizes that correspond to the values in
+        rowsize, and types that correspond to the type of ragged_array
+
+    Examples
+    --------
+
+    Unpacking longitude arrays from a ragged Xarray Dataset:
+
+    .. code-block:: python
+
+        lon = unpack_ragged(ds.lon, ds.rowsize) # return a list[xr.DataArray] (slower)
+        lon = unpack_ragged(ds.lon.values, ds.rowsize) # return a list[np.ndarray] (faster)
+
+    Looping over trajectories in a ragged Xarray Dataset to compute velocities
+    for each:
+
+    .. code-block:: python
+
+        for lon, lat, time in list(zip(
+            unpack_ragged(ds.lon.values, ds.rowsize),
+            unpack_ragged(ds.lat.values, ds.rowsize),
+            unpack_ragged(ds.time.values, ds.rowsize)
+        )):
+            u, v = velocity_from_position(lon, lat, time)
     """
     indices = np.insert(np.cumsum(np.array(rowsize)), 0, 0)
     return [ragged_array[indices[n] : indices[n + 1]] for n in range(indices.size - 1)]

--- a/clouddrift/dataformat.py
+++ b/clouddrift/dataformat.py
@@ -377,3 +377,28 @@ class RaggedArray:
         """
         ak.to_parquet(self.to_awkward(), filename)
         return
+
+
+def unpack(ragged_array: np.ndarray, rowsize: np.ndarray[int]) -> list[np.ndarray]:
+    """Unpack a ragged array into a list of regular arrays.
+
+    Unpacking ragged_array as an np.ndarray is about 2 orders of magnitude
+    faster than unpacking it as an xr.DataArray, so unles you need a DataArray
+    as the result, we recommend passing np.ndarray as input.
+
+    Args:
+        ragged_array (array-like): A ragged_array to unpack
+        rowsize (array-like): An array of integers whose values is the size of
+            each row in the ragged array
+    Returns:
+        unpacked_arrays (list): A list of array-likes with sizes that
+            correspond to the values in rowsize, and types that correspond
+            to the type of ragged_array
+    """
+    unpacked_arrays = []
+    start = 0
+    for rs in rowsize:
+        end = start + int(rs)
+        unpacked_arrays.append(ragged_array[start:end])
+        start = end
+    return unpacked_arrays

--- a/clouddrift/dataformat.py
+++ b/clouddrift/dataformat.py
@@ -395,10 +395,5 @@ def unpack(ragged_array: np.ndarray, rowsize: np.ndarray[int]) -> list[np.ndarra
             correspond to the values in rowsize, and types that correspond
             to the type of ragged_array
     """
-    unpacked_arrays = []
-    start = 0
-    for rs in rowsize:
-        end = start + int(rs)
-        unpacked_arrays.append(ragged_array[start:end])
-        start = end
-    return unpacked_arrays
+    indices = np.insert(np.cumsum(ds.rowsize.values), 0, 0)
+    return [ragged_array[indices[n]:indices[n+1]] for n in range(indices.size - 1)]


### PR DESCRIPTION
* [x] Implementation
* [x] Tests
* [x] Example use in docstring

This function unpacks a ragged array into a list of regular arrays determined by rowsize. In support of #70 and other trajectory-bound-aware functions.

It's implemented using Philippe's EarthCube presentation approach (Xarray case 3).

Before proceeding to complete this PR, I'd like to get feedback on whether you like the direction and the API.

This function works with NumPy arrays and Xarray DataArrays, however passing DataArrays appears to be about 2 orders of magnitude slower. Here's a small benchmark with a ragged Xarray Dataset with 100 trajectories:

```
In [192]: %timeit res = unpack(ds.lon, ds.rowsize)
9.62 ms ± 9.27 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [193]: %timeit res = unpack(ds.lon.values, ds.rowsize.values)
163 µs ± 64.7 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

Example:

```python
from clouddrift.adapters.gdp import to_raggedarray
from clouddrift.analysis import velocity_from_position
from clouddrift.dataformat import unpack

ds = to_raggedarray(n_random_id=100).to_xarray()

for lon, lat, time in list(zip(
    unpack(ds.lon.values, ds.rowsize),
    unpack(ds.lat.values, ds.rowsize),
    unpack(ds.time.values, ds.rowsize)
)):
    u, v = velocity_from_position(lon, lat, time)
    plt.scatter(lon, lat, c=np.sqrt(u**2 + v**2), s=10)
plt.colorbar()
```

![Figure_1](https://user-images.githubusercontent.com/4133310/219106164-50a64b64-87b7-461a-932e-861ba175ba5f.png)

