### PR TITLE
Running code coverage with the automatic tests

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -12,5 +12,5 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: psf/black@stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         os: ["ubuntu-latest"]
         python-version: ["3.9"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: mamba-org/provision-with-micromamba@main
         with:
           environment-file: environment.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,10 @@ jobs:
       - name: Unit testing
         shell: bash -l {0}
         run: |
-              python -m unittest discover -s tests -p "*.py"
+              pip install coverage
+              coverage run -m unittest discover -s tests -p "*.py"
+              coverage xml
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.xml

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # CloudDrift
 ![CI](https://github.com/Cloud-Drift/clouddrift/workflows/CI/badge.svg)
 [![Documentation Status](https://github.com/Cloud-Drift/clouddrift/actions/workflows/docs.yml/badge.svg)](https://cloud-drift.github.io/clouddrift)
+[![codecov](https://codecov.io/gh/Cloud-Drift/clouddrift/branch/main/graph/badge.svg)](https://codecov.io/gh/Cloud-Drift/clouddrift/)
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Cloud-Drift/clouddrift-examples/main?labpath=notebooks)
 [![Available on conda-forge](https://img.shields.io/badge/Anaconda.org-0.6.0-blue.svg)](https://anaconda.org/conda-forge/clouddrift/)
 [![Available on pypi](https://img.shields.io/pypi/v/clouddrift.svg?style=flat&color=blue)](https://pypi.org/project/clouddrift/)


### PR DESCRIPTION
This generates a report on the % of line of codes that are covered by the unit tests, and it is uploaded to codecov.io. See here, https://app.codecov.io/gh/Cloud-Drift/clouddrift/tree/codecov/clouddrift, for the `codecov` branch that I did to test the implementation. We are at 79%, which is pretty good! It's quite useful to identify quickly which parts of the code we are not testing.

I also added a badge on the README, right now, it says unknown because it did not run on the main branch yet.
