### PR TITLE
Expand the OS and Python version matrix in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: test
+name: CI
 
 # Controls when the workflow will run
 on:
@@ -33,6 +33,7 @@ jobs:
               coverage run -m unittest discover -s tests -p "*.py"
               coverage xml
       - name: Upload coverage reports to Codecov
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'
         uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: test
 
 # Controls when the workflow will run
 on:
@@ -13,21 +13,20 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  ci-pygtm:
-    name: 'test'
+  test:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest"]
-        python-version: ["3.9"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+        python-version: ["3.9", "3.10", "3.11"]
     steps:
       - uses: actions/checkout@v3
       - uses: mamba-org/provision-with-micromamba@main
         with:
           environment-file: environment.yml
           environment-name: clouddrift
-      - name: Unit testing
+      - name: Testing
         shell: bash -l {0}
         run: |
               pip install coverage


### PR DESCRIPTION
* Linux, macOS, and Windows
* Python 3.9, 3.10, and 3.11
* Coverage report upload only runs from Linux+Python 3.9 job.

The CI time does go from about a minute to a few minutes, but I think it's worth it.