### PR TITLE
Regular to ragged `fill_value`

### DIFF
--- a/clouddrift/analysis.py
+++ b/clouddrift/analysis.py
@@ -234,7 +234,7 @@ def regular_to_ragged(
     (array([1., 2., 3., 4., 5.]), array([2, 1, 2]))
 
     Alternatively, a different fill value can be specified:
-    
+
     >>> regular_to_ragged(np.array([[1, 2], [3, -999], [4, 5]]), fill_value=-999)
     (array([1., 2., 3., 4., 5.]), array([2, 1, 2]))
 

--- a/clouddrift/analysis.py
+++ b/clouddrift/analysis.py
@@ -210,7 +210,7 @@ def chunk(
 def regular_to_ragged(
     array: np.ndarray, fill_value: float = np.nan
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Convert a two-dimensional array to a ragged array. NaN values in the input array are
+    """Convert a two-dimensional array to a ragged array. Fill values in the input array are
     excluded from the output ragged array.
 
     Parameters
@@ -218,7 +218,7 @@ def regular_to_ragged(
     array : np.ndarray
         A two-dimensional array.
     fill_value : float, optional
-        Fill value to use to determine the bounds of contiguous segments.
+        Fill value used to determine the bounds of contiguous segments.
 
     Returns
     -------
@@ -233,9 +233,8 @@ def regular_to_ragged(
     >>> regular_to_ragged(np.array([[1, 2], [3, np.nan], [4, 5]]))
     (array([1., 2., 3., 4., 5.]), array([2, 1, 2]))
 
-    Alternatively, if the regular array uses a different fill value, you can
-    specify it:
-
+    Alternatively, a different fill value can be specified:
+    
     >>> regular_to_ragged(np.array([[1, 2], [3, -999], [4, 5]]), fill_value=-999)
     (array([1., 2., 3., 4., 5.]), array([2, 1, 2]))
 
@@ -281,7 +280,7 @@ def ragged_to_regular(
 
     Examples
     --------
-    By default, the fill value is NaN:
+    By default, the fill value used is NaN:
 
     >>> ragged_to_regular(np.array([1, 2, 3, 4, 5]), np.array([2, 1, 2]))
     array([[ 1.,  2.],

--- a/clouddrift/analysis.py
+++ b/clouddrift/analysis.py
@@ -225,7 +225,16 @@ def regular_to_ragged(array: np.ndarray, fill_value: float = np.nan) -> tuple[np
 
     Examples
     --------
+    By default, NaN values found in the input regular array are excluded from
+    the output ragged array:
+
     >>> regular_to_ragged(np.array([[1, 2], [3, np.nan], [4, 5]]))
+    (array([1., 2., 3., 4., 5.]), array([2, 1, 2]))
+
+    Alternatively, if the regular array uses a different fill value, you can
+    specify it:
+
+    >>> regular_to_ragged(np.array([[1, 2], [3, -999], [4, 5]]), fill_value=-999)
     (array([1., 2., 3., 4., 5.]), array([2, 1, 2]))
 
     See Also
@@ -243,6 +252,7 @@ def regular_to_ragged(array: np.ndarray, fill_value: float = np.nan) -> tuple[np
 def ragged_to_regular(
     ragged: Union[np.ndarray, pd.Series, xr.DataArray],
     rowsize: Union[list, np.ndarray, pd.Series, xr.DataArray],
+    fill_value: float = np.nan,
 ) -> np.ndarray:
     """Convert a ragged array to a two-dimensional array such that each contiguous segment
     of a ragged array is a row in the two-dimensional array. Each row of the two-dimensional
@@ -259,6 +269,9 @@ def ragged_to_regular(
         A ragged array.
     rowsize : list or np.ndarray[int] or pd.Series or xr.DataArray[int]
         The size of each row in the ragged array.
+    fill_value : float, optional
+        Fill value to use for the trailing elements of each row of the resulting
+        regular array.
 
     Returns
     -------
@@ -267,16 +280,24 @@ def ragged_to_regular(
 
     Examples
     --------
+    By default, the fill value is NaN:
+
     >>> ragged_to_regular(np.array([1, 2, 3, 4, 5]), np.array([2, 1, 2]))
     array([[ 1.,  2.],
            [ 3., nan],
            [ 4.,  5.]])
 
+    You can specify an alternative fill value:
+    >>> ragged_to_regular(np.array([1, 2, 3, 4, 5]), np.array([2, 1, 2]), fill_value=999)
+    array([[ 1.,    2.],
+           [ 3., -999.],
+           [ 4.,    5.]])
+
     See Also
     --------
     :func:`regular_to_ragged`
     """
-    res = np.nan * np.empty((len(rowsize), int(max(rowsize))), dtype=ragged.dtype)
+    res = fill_value * np.empty((len(rowsize), int(max(rowsize))), dtype=ragged.dtype)
     unpacked = unpack_ragged(ragged, rowsize)
     for n in range(len(rowsize)):
         res[n, : int(rowsize[n])] = unpacked[n]

--- a/clouddrift/analysis.py
+++ b/clouddrift/analysis.py
@@ -207,7 +207,7 @@ def chunk(
     return res
 
 
-def regular_to_ragged(array: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+def regular_to_ragged(array: np.ndarray, fill_value: float = np.nan) -> tuple[np.ndarray, np.ndarray]:
     """Convert a two-dimensional array to a ragged array. NaN values in the input array are
     excluded from the output ragged array.
 
@@ -215,6 +215,8 @@ def regular_to_ragged(array: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     ----------
     array : np.ndarray
         A two-dimensional array.
+    fill_value : float, optional
+        Fill value to use to determine the bounds of contiguous segments.
 
     Returns
     -------
@@ -231,7 +233,11 @@ def regular_to_ragged(array: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
     :func:`ragged_to_regular`
     """
     ragged = array.flatten()
-    return ragged[~np.isnan(ragged)], np.sum(~np.isnan(array), axis=1)
+    if np.isnan(fill_value):
+        valid = ~np.isnan(ragged)
+    else:
+        valid = ragged != fill_value
+    return ragged[valid], np.sum(valid, axis=1)
 
 
 def ragged_to_regular(

--- a/clouddrift/analysis.py
+++ b/clouddrift/analysis.py
@@ -241,12 +241,11 @@ def regular_to_ragged(array: np.ndarray, fill_value: float = np.nan) -> tuple[np
     --------
     :func:`ragged_to_regular`
     """
-    ragged = array.flatten()
     if np.isnan(fill_value):
-        valid = ~np.isnan(ragged)
+        valid = ~np.isnan(array)
     else:
-        valid = ragged != fill_value
-    return ragged[valid], np.sum(valid, axis=1)
+        valid = array != fill_value
+    return array[valid], np.sum(valid, axis=1)
 
 
 def ragged_to_regular(

--- a/clouddrift/analysis.py
+++ b/clouddrift/analysis.py
@@ -207,7 +207,9 @@ def chunk(
     return res
 
 
-def regular_to_ragged(array: np.ndarray, fill_value: float = np.nan) -> tuple[np.ndarray, np.ndarray]:
+def regular_to_ragged(
+    array: np.ndarray, fill_value: float = np.nan
+) -> tuple[np.ndarray, np.ndarray]:
     """Convert a two-dimensional array to a ragged array. NaN values in the input array are
     excluded from the output ragged array.
 
@@ -296,7 +298,7 @@ def ragged_to_regular(
     --------
     :func:`regular_to_ragged`
     """
-    res = fill_value * np.empty((len(rowsize), int(max(rowsize))), dtype=ragged.dtype)
+    res = fill_value * np.ones((len(rowsize), int(max(rowsize))), dtype=ragged.dtype)
     unpacked = unpack_ragged(ragged, rowsize)
     for n in range(len(rowsize)):
         res[n, : int(rowsize[n])] = unpacked[n]

--- a/tests/analysis_tests.py
+++ b/tests/analysis_tests.py
@@ -241,12 +241,29 @@ class ragged_to_regular_tests(unittest.TestCase):
             np.all(result[~np.isnan(result)] == expected[~np.isnan(expected)])
         )
 
+    def test_ragged_to_regular_fill_value(self):
+        ragged = np.array([1, 2, 3, 4, 5])
+        rowsize = [2, 1, 2]
+        expected = np.array([[1, 2], [3, -999], [4, 5]])
+
+        result = ragged_to_regular(ragged, rowsize, fill_value=-999)
+        self.assertTrue(np.all(result == expected))
+
     def test_regular_to_ragged(self):
-        matrix = np.array([[1, 2], [3, np.nan], [4, 5]])
+        regular = np.array([[1, 2], [3, np.nan], [4, 5]])
         expected = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
         expected_rowsize = np.array([2, 1, 2])
 
-        result, rowsize = regular_to_ragged(matrix)
+        result, rowsize = regular_to_ragged(regular)
+        self.assertTrue(np.all(result == expected))
+        self.assertTrue(np.all(rowsize == expected_rowsize))
+
+    def test_regular_to_ragged_fill_value(self):
+        regular = np.array([[1, 2], [3, -999], [4, 5]])
+        expected = np.array([1.0, 2.0, 3.0, 4.0, 5.0])
+        expected_rowsize = np.array([2, 1, 2])
+
+        result, rowsize = regular_to_ragged(regular, fill_value=-999)
         self.assertTrue(np.all(result == expected))
         self.assertTrue(np.all(rowsize == expected_rowsize))
 


### PR DESCRIPTION
Add optional `fill_value` for both `ragged_to_regular` and `regular_to_ragged`. Default value remains `np.nan`.

Closes #168.