### PR TITLE
Datasets module with the GDP hourly accessor

### DIFF
--- a/clouddrift/__init__.py
+++ b/clouddrift/__init__.py
@@ -5,5 +5,6 @@ __version__ = version
 from clouddrift.raggedarray import RaggedArray
 import clouddrift.adapters
 import clouddrift.analysis
+import clouddrift.datasets
 import clouddrift.haversine
 import clouddrift.sphere

--- a/clouddrift/datasets.py
+++ b/clouddrift/datasets.py
@@ -1,0 +1,18 @@
+"""
+This module provides functions to easily access ragged-array datasets.
+"""
+
+import xarray as xr
+
+
+def gdp1h() -> xr.Dataset:
+    """
+    Returns the hourly GDP dataset as an Xarray dataset.
+
+    Returns
+    -------
+    xarray.Dataset
+        GDP1h dataset
+    """
+    url = "https://noaa-oar-hourly-gdp-pds.s3.amazonaws.com/latest/gdp_v2.00.zarr"
+    return xr.open_dataset(url, engine="zarr")

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -33,6 +33,13 @@ Analysis
   :members:
   :undoc-members:
 
+Datasets
+--------
+
+.. automodule:: clouddrift.datasets
+  :members:
+  :undoc-members:
+
 Haversine
 ---------
 

--- a/environment.yml
+++ b/environment.yml
@@ -4,13 +4,16 @@ channels:
 dependencies:
   - python>=3.9
   - numpy>=1.21.6
-  - xarray>=2022.6.0
-  - netcdf4>=1.6.1
+  - xarray>=2023.5.0
+  - netcdf4>=1.6.4
   - pyarrow>=9.0.0
   - tqdm>=4.64.1
   - fsspec>=2022.8.2
   - llvmlite>=0.38.1
   - awkward>=2.0.0
   - pip>=22.2.2
+  - aiohttp>=3.8.4
+  - requests>=2.31.0
+  - zarr>=2.14.2
   - pip:
     - git+https://github.com/Cloud-Drift/clouddrift.git

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,13 +20,16 @@ classifiers = [
 ]
 
 dependencies = [
+    "aiohttp>=3.8.4",
+    "awkward>=2.0.0",
+    "fsspec>=2022.3.0",
+    "netcdf4>=1.6.4",
     "numpy>=1.22.4",
-    "xarray>=2022.3.0",
-    "netcdf4>=1.5.8",
     "pyarrow>=8.0.0",
     "tqdm>=4.64.0",
-    "fsspec>=2022.3.0",
-    "awkward>=2.0.0",
+    "requests>=2.31.0",
+    "xarray>=2023.5.0",
+    "zarr>=2.14.2",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clouddrift"
-version = "0.14.0"
+version = "0.15.0"
 authors = [
   { name="Shane Elipot", email="selipot@miami.edu" },
   { name="Philippe Miron", email="philippemiron@gmail.com" },

--- a/tests/datasets_tests.py
+++ b/tests/datasets_tests.py
@@ -1,0 +1,12 @@
+from clouddrift import datasets
+import unittest
+
+
+if __name__ == "__main__":
+    unittest.main()
+
+
+class datasets_tests(unittest.TestCase):
+    def test_gdp1h_opens(self):
+        ds = datasets.gdp1h()
+        self.assertTrue(ds)


### PR DESCRIPTION
* [x] Implementation
* [x] Test
* [x] Docs

New module to provide a convenience accessor to hourly GDP dataset from the Zarr dataset on AWS.

```python
In [1]: from clouddrift import datasets

In [2]: datasets.gdp1h()
Out[2]: 
<xarray.Dataset>
Dimensions:                (traj: 17324, obs: 165754333)
Coordinates:
    ids                    (obs) int64 ...
    lat                    (obs) float32 ...
    lon                    (obs) float32 ...
    time                   (obs) datetime64[ns] ...
Dimensions without coordinates: traj, obs
Data variables: (12/55)
    BuoyTypeManufacturer   (traj) |S20 ...
    BuoyTypeSensorArray    (traj) |S20 ...
    CurrentProgram         (traj) float64 ...
    DeployingCountry       (traj) |S20 ...
    DeployingShip          (traj) |S20 ...
    DeploymentComments     (traj) |S20 ...
    ...                     ...
    sst1                   (obs) float64 ...
    sst2                   (obs) float64 ...
    typebuoy               (traj) |S10 ...
    typedeath              (traj) int8 ...
    ve                     (obs) float32 ...
    vn                     (obs) float32 ...
Attributes: (12/16)
    Conventions:       CF-1.6
    acknowledgement:   Elipot, Shane; Sykulski, Adam; Lumpkin, Rick; Centurio...
    contributor_name:  NOAA Global Drifter Program
    contributor_role:  Data Acquisition Center
    date_created:      2022-12-09T06:02:29.684949
    doi:               10.25921/x46c-3620
    ...                ...
    processing_level:  Level 2 QC by GDP drifter DAC
    publisher_email:   aoml.dftr@noaa.gov
    publisher_name:    GDP Drifter DAC
    publisher_url:     https://www.aoml.noaa.gov/phod/gdp
    summary:           Global Drifter Program hourly data
    title:             Global Drifter Program hourly drifting buoy collection
```

@philippemiron can you check if this works when installing with Conda from the environment.yml file? I added the required dependencies for remote Zarr access however on my end it still complains about requests and aiohttp missing, despite them being listed as installed. It must be my misunderstanding of how Conda works.

I also brought netCDF4 and Xarray dependency versions to the latest. Probably not necessary but good to keep up to date as long as the new versions work.

This PR bumps the project version to 0.15.0.