### PR TITLE
Fix N-d velocity and position functions with `time_axis`

### DIFF
--- a/clouddrift/analysis.py
+++ b/clouddrift/analysis.py
@@ -612,17 +612,15 @@ def position_from_velocity(
             f" {len(x.shape) - 1}])."
         )
 
-    # Nominal order of axes on input, i.e. (0, 1, 2, ..., N-1)
-    target_axes = list(range(len(u.shape)))
-
-    # If time_axis is not the last one, transpose the inputs
-    if time_axis != -1 and time_axis < len(u.shape) - 1:
-        target_axes.append(target_axes.pop(target_axes.index(time_axis)))
-
-    # Reshape the inputs to ensure the time axis is last (fast-varying)
-    u_ = np.transpose(u, target_axes)
-    v_ = np.transpose(v, target_axes)
-    time_ = np.transpose(time, target_axes)
+    # Swap axes so that we can differentiate along the last axis.
+    # This is a syntax convenience rather than memory access optimization:
+    # np.swapaxes returns a view of the array, not a copy, if the input is a
+    # NumPy array. Otherwise, it returns a copy. For readability, introduce new
+    # variable names so that we can more easily differentiate between the
+    # original arrays and those with swapped axes.
+    u_ = np.swapaxes(u, time_axis, -1)
+    v_ = np.swapaxes(v, time_axis, -1)
+    time_ = np.swapaxes(time, time_axis, -1)
 
     x = np.zeros(u_.shape, dtype=u.dtype)
     y = np.zeros(v_.shape, dtype=v.dtype)
@@ -659,10 +657,7 @@ def position_from_velocity(
     else:
         raise ValueError('coord_system must be "spherical" or "cartesian".')
 
-    if target_axes == list(range(len(u.shape))):
-        return x, y
-    else:
-        return np.transpose(x, target_axes), np.transpose(y, target_axes)
+    return np.swapaxes(x, time_axis, -1), np.swapaxes(y, time_axis, -1)
 
 
 def velocity_from_position(

--- a/clouddrift/analysis.py
+++ b/clouddrift/analysis.py
@@ -754,17 +754,12 @@ def velocity_from_position(
             f" {len(x.shape) - 1}])."
         )
 
-    # Nominal order of axes on input, i.e. (0, 1, 2, ..., N-1)
-    # target_axes = list(range(len(x.shape)))
-
-    # If time_axis is not the last one, transpose the inputs
-    # if time_axis != -1 and time_axis < len(x.shape) - 1:
-    #    target_axes.append(target_axes.pop(target_axes.index(time_axis)))
-
-    # Reshape the inputs to ensure the time axis is last (fast-varying)
-    # x_ = np.transpose(x, target_axes)
-    # y_ = np.transpose(y, target_axes)
-    # time_ = np.transpose(time, target_axes)
+    # Swap axes so that we can differentiate along the last axis.
+    # This is a syntax convenience rather than memory access optimization:
+    # np.swapaxes returns a view of the array, not a copy, if the input is a
+    # NumPy array. Otherwise, it returns a copy. For readability, introduce new
+    # variable names so that we can more easily differentiate between the
+    # original arrays and those with swapped axes.
     x_ = np.swapaxes(x, time_axis, -1)
     y_ = np.swapaxes(y, time_axis, -1)
     time_ = np.swapaxes(time, time_axis, -1)
@@ -876,11 +871,11 @@ def velocity_from_position(
             'difference_scheme must be "forward", "backward", or "centered".'
         )
 
-    # if target_axes == list(range(len(x.shape))):
-    #    return dx / dt, dy / dt
-    # else:
-    #    return np.transpose(dx / dt, target_axes), np.transpose(dy / dt, target_axes)
-    return np.swapaxes(dx / dt, time_axis, -1), np.swapaxes(dy / dt, time_axis, -1)
+    # This should avoid an array copy when returning the result
+    dx /= dt
+    dy /= dt
+
+    return np.swapaxes(dx, time_axis, -1), np.swapaxes(dy, time_axis, -1)
 
 
 def mask_var(

--- a/clouddrift/analysis.py
+++ b/clouddrift/analysis.py
@@ -755,16 +755,19 @@ def velocity_from_position(
         )
 
     # Nominal order of axes on input, i.e. (0, 1, 2, ..., N-1)
-    target_axes = list(range(len(x.shape)))
+    # target_axes = list(range(len(x.shape)))
 
     # If time_axis is not the last one, transpose the inputs
-    if time_axis != -1 and time_axis < len(x.shape) - 1:
-        target_axes.append(target_axes.pop(target_axes.index(time_axis)))
+    # if time_axis != -1 and time_axis < len(x.shape) - 1:
+    #    target_axes.append(target_axes.pop(target_axes.index(time_axis)))
 
     # Reshape the inputs to ensure the time axis is last (fast-varying)
-    x_ = np.transpose(x, target_axes)
-    y_ = np.transpose(y, target_axes)
-    time_ = np.transpose(time, target_axes)
+    # x_ = np.transpose(x, target_axes)
+    # y_ = np.transpose(y, target_axes)
+    # time_ = np.transpose(time, target_axes)
+    x_ = np.swapaxes(x, time_axis, -1)
+    y_ = np.swapaxes(y, time_axis, -1)
+    time_ = np.swapaxes(time, time_axis, -1)
 
     dx = np.empty(x_.shape)
     dy = np.empty(y_.shape)
@@ -873,10 +876,11 @@ def velocity_from_position(
             'difference_scheme must be "forward", "backward", or "centered".'
         )
 
-    if target_axes == list(range(len(x.shape))):
-        return dx / dt, dy / dt
-    else:
-        return np.transpose(dx / dt, target_axes), np.transpose(dy / dt, target_axes)
+    # if target_axes == list(range(len(x.shape))):
+    #    return dx / dt, dy / dt
+    # else:
+    #    return np.transpose(dx / dt, target_axes), np.transpose(dy / dt, target_axes)
+    return np.swapaxes(dx / dt, time_axis, -1), np.swapaxes(dy / dt, time_axis, -1)
 
 
 def mask_var(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clouddrift"
-version = "0.20.0"
+version = "0.20.1"
 authors = [
   { name="Shane Elipot", email="selipot@miami.edu" },
   { name="Philippe Miron", email="philippemiron@gmail.com" },

--- a/tests/analysis_tests.py
+++ b/tests/analysis_tests.py
@@ -525,7 +525,6 @@ class position_from_velocity_tests(unittest.TestCase):
         self.assertTrue(np.allclose(lon.shape, expected_lat.shape))
 
     def test_time_axis(self):
-
         uf = np.reshape(np.tile(self.uf, 6), (2, 3, self.uf.size))
         vf = np.reshape(np.tile(self.vf, 6), (2, 3, self.vf.size))
         time = np.reshape(np.tile(self.time, 6), (2, 3, self.time.size))
@@ -533,7 +532,6 @@ class position_from_velocity_tests(unittest.TestCase):
         expected_lat = np.reshape(np.tile(self.lat, 6), (2, 3, self.lat.size))
 
         for time_axis in [0, 1, 2]:
-
             # Pass inputs with swapped axes and differentiate along that time
             # axis.
             lon, lat = position_from_velocity(
@@ -623,7 +621,6 @@ class velocity_from_position_tests(unittest.TestCase):
         self.assertTrue(np.all(vf.shape == expected_vf.shape))
 
     def test_time_axis(self):
-
         lon = np.reshape(np.tile(self.lon, 6), (2, 3, self.lon.size))
         lat = np.reshape(np.tile(self.lat, 6), (2, 3, self.lat.size))
         time = np.reshape(np.tile(self.time, 6), (2, 3, self.time.size))
@@ -631,7 +628,6 @@ class velocity_from_position_tests(unittest.TestCase):
         expected_vf = np.reshape(np.tile(self.vf, 6), (2, 3, self.vf.size))
 
         for time_axis in [0, 1, 2]:
-
             # Pass inputs with swapped axes and differentiate along that time
             # axis.
             uf, vf = velocity_from_position(

--- a/tests/analysis_tests.py
+++ b/tests/analysis_tests.py
@@ -621,26 +621,33 @@ class velocity_from_position_tests(unittest.TestCase):
         self.assertTrue(np.all(vf.shape == expected_vf.shape))
 
     def test_time_axis(self):
-        lon = np.transpose(
-            np.reshape(np.tile(self.lon, 4), (2, 2, self.lon.size)), (0, 2, 1)
-        )
-        lat = np.transpose(
-            np.reshape(np.tile(self.lat, 4), (2, 2, self.lat.size)), (0, 2, 1)
-        )
-        time = np.transpose(
-            np.reshape(np.tile(self.time, 4), (2, 2, self.time.size)), (0, 2, 1)
-        )
-        expected_uf = np.transpose(
-            np.reshape(np.tile(self.uf, 4), (2, 2, self.uf.size)), (0, 2, 1)
-        )
-        expected_vf = np.transpose(
-            np.reshape(np.tile(self.vf, 4), (2, 2, self.vf.size)), (0, 2, 1)
-        )
-        uf, vf = velocity_from_position(lon, lat, time, time_axis=1)
-        self.assertTrue(np.all(uf == expected_uf))
-        self.assertTrue(np.all(vf == expected_vf))
-        self.assertTrue(np.all(uf.shape == expected_uf.shape))
-        self.assertTrue(np.all(vf.shape == expected_vf.shape))
+
+        lon = np.reshape(np.tile(self.lon, 6), (2, 3, self.lon.size))
+        lat = np.reshape(np.tile(self.lat, 6), (2, 3, self.lat.size))
+        time = np.reshape(np.tile(self.time, 6), (2, 3, self.time.size))
+        expected_uf = np.reshape(np.tile(self.uf, 6), (2, 3, self.uf.size))
+        expected_vf = np.reshape(np.tile(self.vf, 6), (2, 3, self.vf.size))
+
+        for time_axis in [0, 1, 2]:
+
+            # Pass inputs with swapped axes and differentiate along that time
+            # axis.
+            uf, vf = velocity_from_position(
+                np.swapaxes(lon, time_axis, -1),
+                np.swapaxes(lat, time_axis, -1),
+                np.swapaxes(time, time_axis, -1),
+                time_axis=time_axis,
+            )
+
+            # Swap axes back to compare with the expected result.
+            self.assertTrue(np.all(np.swapaxes(uf, time_axis, -1) == expected_uf))
+            self.assertTrue(np.all(np.swapaxes(vf, time_axis, -1) == expected_vf))
+            self.assertTrue(
+                np.all(np.swapaxes(uf, time_axis, -1).shape == expected_uf.shape)
+            )
+            self.assertTrue(
+                np.all(np.swapaxes(vf, time_axis, -1).shape == expected_uf.shape)
+            )
 
 
 class apply_ragged_tests(unittest.TestCase):


### PR DESCRIPTION
Fixes #229.

* Now using `np.swapaxes` as the most straightforward way to do this.
* Expanded `time_axis` tests to do the differentiation/integration along each of the 3 axes of a 3-d array.