### PR TITLE
Allow subsetting by string or object ids

### DIFF
--- a/clouddrift/analysis.py
+++ b/clouddrift/analysis.py
@@ -937,7 +937,9 @@ def mask_var(
     if isinstance(criterion, tuple):  # min/max defining range
         mask = np.logical_and(var >= criterion[0], var <= criterion[1])
     elif isinstance(criterion, list):  # select multiple values
-        mask = xr.zeros_like(var)
+        # Ensure we define the mask as boolean, otherwise it will inherit
+        # the dtype of the variable which may be a string, object, or other.
+        mask = xr.zeros_like(var, dtype=bool)
         for v in criterion:
             mask = np.logical_or(mask, var == v)
     else:  # select one specific value

--- a/clouddrift/analysis.py
+++ b/clouddrift/analysis.py
@@ -897,7 +897,8 @@ def velocity_from_position(
 
 
 def mask_var(
-    var: xr.DataArray, criterion: Union[tuple, list, bool, float, int]
+    var: xr.DataArray,
+    criterion: Union[tuple, list, np.ndarray, xr.DataArray, bool, float, int],
 ) -> xr.DataArray:
     """Return the mask of a subset of the data matching a test criterion.
 
@@ -905,10 +906,10 @@ def mask_var(
     ----------
     var : xr.DataArray
         DataArray to be subset by the criterion
-    criterion : Union[tuple, list, bool, float, int]
+    criterion : array-like
         The criterion can take three forms:
         - tuple: (min, max) defining a range
-        - list: [value1, value2, valueN] defining multiples values
+        - list, np.ndarray, or xr.DataArray: An array-like defining multiples values
         - scalar: value defining a single value
 
     Examples

--- a/clouddrift/analysis.py
+++ b/clouddrift/analysis.py
@@ -936,7 +936,9 @@ def mask_var(
     """
     if isinstance(criterion, tuple):  # min/max defining range
         mask = np.logical_and(var >= criterion[0], var <= criterion[1])
-    elif isinstance(criterion, list):  # select multiple values
+    elif isinstance(
+        criterion, (list, np.ndarray, xr.DataArray)
+    ):  # select multiple values
         # Ensure we define the mask as boolean, otherwise it will inherit
         # the dtype of the variable which may be a string, object, or other.
         mask = xr.zeros_like(var, dtype=bool)

--- a/clouddrift/analysis.py
+++ b/clouddrift/analysis.py
@@ -1003,7 +1003,10 @@ def subset(
     Retrieve a specific time period:
     >>> subset(ds, {"time": (np.datetime64("2000-01-01"), np.datetime64("2020-01-31"))})
 
-    Note: To subset time variable, the range has to be defined as a function type of the variable. By default, `xarray` uses `np.datetime64` to represent datetime data. If the datetime data is a `datetime.datetime`, or `pd.Timestamp`, the range would have to be define accordingly.
+    Note that to subset time variable, the range has to be defined as a function
+    type of the variable. By default, ``xarray`` uses ``np.datetime64`` to
+    represent datetime data. If the datetime data is a ``datetime.datetime``, or
+    ``pd.Timestamp``, the range would have to be defined accordingly.
 
     Those criteria can also be combined:
     >>> subset(ds, {"lat": (21, 31), "lon": (-98, -78), "drogue_status": True, "sst": (303.15, np.inf), "time": (np.datetime64("2000-01-01"), np.datetime64("2020-01-31"))})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clouddrift"
-version = "0.22.0"
+version = "0.21.3"
 authors = [
   { name="Shane Elipot", email="selipot@miami.edu" },
   { name="Philippe Miron", email="philippemiron@gmail.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clouddrift"
-version = "0.21.2"
+version = "0.22.0"
 authors = [
   { name="Shane Elipot", email="selipot@miami.edu" },
   { name="Philippe Miron", email="philippemiron@gmail.com" },

--- a/tests/analysis_tests.py
+++ b/tests/analysis_tests.py
@@ -858,6 +858,15 @@ class subset_tests(unittest.TestCase):
         ds_sub = subset(ds_str, {"ID": list(ds_str["ID"].values[:2])})
         self.assertTrue(ds_sub["ID"].size == 2)
 
+    def test_arraylike_criterion(self):
+        # DataArray
+        ds_sub = subset(self.ds, {"ID": self.ds["ID"][:2]})
+        self.assertTrue(ds_sub["ID"].size == 2)
+
+        # NumPy array
+        ds_sub = subset(self.ds, {"ID": self.ds["ID"][:2].values})
+        self.assertTrue(ds_sub["ID"].size == 2)
+
 
 class unpack_ragged_tests(unittest.TestCase):
     def test_unpack_ragged(self):

--- a/tests/analysis_tests.py
+++ b/tests/analysis_tests.py
@@ -36,8 +36,6 @@ def sample_ragged_array() -> RaggedArray:
     ]
     rowsize = [len(x) for x in longitude]
     ids = [[d] * rowsize[i] for i, d in enumerate(drifter_id)]
-    nb_obs = np.sum(rowsize)
-    nb_traj = len(drifter_id)
     attrs_global = {
         "title": "test trajectories",
         "history": "version xyz",
@@ -796,7 +794,6 @@ class subset_tests(unittest.TestCase):
     def test_range(self):
         # positive
         ds_sub = subset(self.ds, {"lon": (0, 180)})
-        print(ds_sub)
         traj_idx = np.insert(np.cumsum(ds_sub["rowsize"].values), 0, 0)
         self.assertTrue(
             all(ds_sub.lon[slice(traj_idx[0], traj_idx[1])] == [51, 61, 71])
@@ -840,6 +837,26 @@ class subset_tests(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             subset(self.ds, {"lon": (0, 180), "a": (0, 10)})
+
+    def test_ragged_array_with_id_as_str(self):
+        ds_str = self.ds.copy()
+        ds_str["ID"].values = ds_str["ID"].astype(str)
+
+        ds_sub = subset(ds_str, {"ID": ds_str["ID"].values[0]})
+        self.assertTrue(ds_sub["ID"].size == 1)
+
+        ds_sub = subset(ds_str, {"ID": list(ds_str["ID"].values[:2])})
+        self.assertTrue(ds_sub["ID"].size == 2)
+
+    def test_ragged_array_with_id_as_object(self):
+        ds_str = self.ds.copy()
+        ds_str["ID"].values = ds_str["ID"].astype(object)
+
+        ds_sub = subset(ds_str, {"ID": ds_str["ID"].values[0]})
+        self.assertTrue(ds_sub["ID"].size == 1)
+
+        ds_sub = subset(ds_str, {"ID": list(ds_str["ID"].values[:2])})
+        self.assertTrue(ds_sub["ID"].size == 2)
 
 
 class unpack_ragged_tests(unittest.TestCase):


### PR DESCRIPTION
There was a subtle bug in `mask_var` that was preventing this. It didn't manifest on datasets with integer IDs like GDP, but it did in datasets like MOSAiC or Spotter which are objects or strings.

This PR also slightly expands the functionality of `subset` by not limiting the criterion of a sequence to be a `list`, and can now be an array-like (i.e. `list`, `np.ndarray`, or `xr.DataArray`).

This PR bumps the version to 0.21.3.