### PR TITLE
Avoid keeping entire ids in memory

### DIFF
--- a/clouddrift/analysis.py
+++ b/clouddrift/analysis.py
@@ -1040,8 +1040,9 @@ def subset(
         mask_obs[slice(traj_idx[i], traj_idx[i + 1])] = False
 
     # remove trajectory completely filtered in mask_obs
-    ids = np.repeat(ds[id_var_name].values, ds[rowsize_var_name].values)
-    ids_with_mask_obs = ids[mask_obs]
+    ids_with_mask_obs = np.repeat(ds[id_var_name].values, ds[rowsize_var_name].values)[
+        mask_obs
+    ]
     mask_traj = np.logical_and(
         mask_traj, np.in1d(ds[id_var_name], np.unique(ids_with_mask_obs))
     )


### PR DESCRIPTION
Introduced in 0.20.1 when I generalized `subset`.

We compute `ids(obs)` on the fly but really only use them to apply the mask. Before this PR the code kept a copy of `ids` in memory while `subset` was in progress, and this is not necessary.

Amazingly, when subsetting one (1) trajectory by ID from gdp-v2.01, this one-line change reduces memory use from ~2.8 GB down to ~1.8GB.