### PR TITLE
Cast GDP float64 data to float32 as an option (default)

### DIFF
--- a/clouddrift/adapters/gdp.py
+++ b/clouddrift/adapters/gdp.py
@@ -64,6 +64,33 @@ GDP_METADATA = [
 ]
 
 
+def cast_float64_variables_to_float32(
+    ds: xr.Dataset, variables_to_skip: list[str] = ["time", "lat", "lon"]
+) -> xr.Dataset:
+    """Cast all float64 variables except ``variables_to_skip`` to float32.
+    Extra precision from float64 is not needed and takes up memory and disk
+    space.
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+        Dataset to modify
+    variables_to_skip : list[str]
+        List of variables to skip; default is ["time", "lat", "lon"].
+
+    Returns
+    -------
+    ds : xr.Dataset
+        Modified dataset
+    """
+    for var in ds.variables:
+        if var in variables_to_skip:
+            continue
+        if ds[var].dtype == "float64":
+            ds[var] = ds[var].astype("float32")
+    return ds
+
+
 def parse_directory_file(filename: str) -> pd.DataFrame:
     """Read a GDP directory file that contains metadata of drifter releases.
 

--- a/clouddrift/adapters/gdp1h.py
+++ b/clouddrift/adapters/gdp1h.py
@@ -510,6 +510,9 @@ def preprocess(index: int, **kwargs) -> xr.Dataset:
     # rename variables
     ds = ds.rename_vars({"longitude": "lon", "latitude": "lat"})
 
+    # Cast float64 variables to float32 to reduce memory footprint.
+    ds = gdp.cast_float64_variables_to_float32(ds)
+
     return ds
 
 

--- a/clouddrift/adapters/gdp6h.py
+++ b/clouddrift/adapters/gdp6h.py
@@ -421,6 +421,9 @@ def preprocess(index: int, **kwargs) -> xr.Dataset:
     # rename variables
     ds = ds.rename_vars({"longitude": "lon", "latitude": "lat"})
 
+    # Cast float64 variables to float32 to reduce memory footprint.
+    ds = gdp.cast_float64_variables_to_float32(ds)
+
     return ds
 
 

--- a/clouddrift/raggedarray.py
+++ b/clouddrift/raggedarray.py
@@ -386,7 +386,8 @@ class RaggedArray:
         Parameters
         ----------
         cast_to_float32 : bool, optional
-            Cast all variables to float32 (default is True)
+            Cast all float64 variables to float32 (default is True). This option aims at
+            minimizing the size of the xarray dataset.
 
         Returns
         -------

--- a/clouddrift/raggedarray.py
+++ b/clouddrift/raggedarray.py
@@ -406,17 +406,7 @@ class RaggedArray:
         for var in self.data.keys():
             xr_data[var] = (["obs"], self.data[var], self.attrs_variables[var])
 
-        ds = xr.Dataset(coords=xr_coords, data_vars=xr_data, attrs=self.attrs_global)
-
-        # If any of the upstream floating-point data is double, cast to float.
-        if cast_to_float32:
-            for var in ds.variables:
-                if var == "time":
-                    continue
-                if ds[var].dtype == "float64":
-                    ds[var] = ds[var].astype("float32")
-
-        return ds
+        return xr.Dataset(coords=xr_coords, data_vars=xr_data, attrs=self.attrs_global)
 
     def to_awkward(self):
         """Convert ragged array object to an Awkward Array.


### PR DESCRIPTION
This casts all float64 variables to float32 before returning the Dataset in the `RaggedArray.to_xarray()` method, but give an option to not do it if desired. I tested it with a small gdp-2.01 file (10 random drifters) and it works.

Can you confirm that float32 is OK for longitude and latitude variables? We get precision of 7 digits. For a drifter in the 3-digit longitudes, precision is down to O(10 m). Is it sufficient?