### PR TITLE
Add `axis` to `apply_ragged` and `unpack_ragged`

### DIFF
--- a/clouddrift/analysis.py
+++ b/clouddrift/analysis.py
@@ -1158,4 +1158,6 @@ def unpack_ragged(
     if isinstance(rows, int):
         rows = [rows]
 
-    return [ragged_array[indices[n] : indices[n + 1]] for n in rows]
+    unpacked = np.split(ragged_array, indices[1:-1])
+
+    return [unpacked[i] for i in rows]

--- a/clouddrift/sphere.py
+++ b/clouddrift/sphere.py
@@ -709,11 +709,6 @@ def coriolis_frequency(
     f : float or np.ndarray
         Signed Coriolis frequency in radian per seconds.
 
-    Raises
-    ------
-    Warning
-        Raised if the input latitudes are not in the expected range [-90, 90].
-
     Examples
     --------
     >>> f = coriolis_frequency(np.array([0, 45, 90]))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clouddrift"
-version = "0.22.0"
+version = "0.23.0"
 authors = [
   { name="Shane Elipot", email="selipot@miami.edu" },
   { name="Philippe Miron", email="philippemiron@gmail.com" },

--- a/tests/analysis_tests.py
+++ b/tests/analysis_tests.py
@@ -756,6 +756,21 @@ class apply_ragged_tests(unittest.TestCase):
         )
         self.assertTrue(np.all(y == np.array([1, 4, 9, 16])))
 
+    def test_with_axis(self):
+        x = np.arange((6)).reshape((3, 2))
+        func = lambda x: x**2
+        rowsize = [2, 1]
+        y = apply_ragged(func, x, rowsize, axis=0)
+        self.assertTrue(np.all(y == apply_ragged(func, x, rowsize)))
+
+        with self.assertRaises(ValueError):
+            y = apply_ragged(func, x.T, rowsize, axis=0)
+
+        rowsize = [1, 1]
+        y0 = apply_ragged(func, x.T, [1, 1], axis=0)
+        y1 = apply_ragged(func, x, [1, 1], axis=1)
+        self.assertTrue(np.all(y0 == y1.T))
+
     def test_velocity_dataarray(self):
         for executor in [futures.ThreadPoolExecutor(), futures.ProcessPoolExecutor()]:
             u, v = apply_ragged(

--- a/tests/analysis_tests.py
+++ b/tests/analysis_tests.py
@@ -719,26 +719,6 @@ class apply_ragged_tests(unittest.TestCase):
         )
         self.assertTrue(np.all(y == np.array([1, 4, 9, 16])))
 
-    def test_velocity_ndarray(self):
-        for executor in [futures.ThreadPoolExecutor(), futures.ProcessPoolExecutor()]:
-            u, v = apply_ragged(
-                velocity_from_position,
-                [self.x, self.y, self.t],
-                self.rowsize,
-                coord_system="cartesian",
-                executor=executor,
-            )
-            self.assertIsNone(
-                np.testing.assert_allclose(
-                    u, [1.0, 1.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0, 3.0]
-                )
-            )
-            self.assertIsNone(
-                np.testing.assert_allclose(
-                    v, [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
-                )
-            )
-
     def test_with_rows(self):
         y = apply_ragged(
             lambda x: x**2,
@@ -770,6 +750,26 @@ class apply_ragged_tests(unittest.TestCase):
         y0 = apply_ragged(func, x.T, [1, 1], axis=0)
         y1 = apply_ragged(func, x, [1, 1], axis=1)
         self.assertTrue(np.all(y0 == y1.T))
+
+    def test_velocity_ndarray(self):
+        for executor in [futures.ThreadPoolExecutor(), futures.ProcessPoolExecutor()]:
+            u, v = apply_ragged(
+                velocity_from_position,
+                [self.x, self.y, self.t],
+                self.rowsize,
+                coord_system="cartesian",
+                executor=executor,
+            )
+            self.assertIsNone(
+                np.testing.assert_allclose(
+                    u, [1.0, 1.0, 2.0, 2.0, 2.0, 3.0, 3.0, 3.0, 3.0]
+                )
+            )
+            self.assertIsNone(
+                np.testing.assert_allclose(
+                    v, [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]
+                )
+            )
 
     def test_velocity_dataarray(self):
         for executor in [futures.ThreadPoolExecutor(), futures.ProcessPoolExecutor()]:

--- a/tests/analysis_tests.py
+++ b/tests/analysis_tests.py
@@ -737,19 +737,39 @@ class apply_ragged_tests(unittest.TestCase):
         self.assertTrue(np.all(y == np.array([1, 4, 9, 16])))
 
     def test_with_axis(self):
+        # Test that axis=0 is the default.
         x = np.arange((6)).reshape((3, 2))
         func = lambda x: x**2
         rowsize = [2, 1]
         y = apply_ragged(func, x, rowsize, axis=0)
         self.assertTrue(np.all(y == apply_ragged(func, x, rowsize)))
 
+        # Test that the rowsize is checked against the correct axis.
         with self.assertRaises(ValueError):
             y = apply_ragged(func, x.T, rowsize, axis=0)
 
+        # Test that applying an element-wise function on a 2-d array over
+        # ragged axis 1 is th same as applying it to the transpose over ragged
+        # axis 0.
         rowsize = [1, 1]
-        y0 = apply_ragged(func, x.T, [1, 1], axis=0)
-        y1 = apply_ragged(func, x, [1, 1], axis=1)
+        y0 = apply_ragged(func, x.T, rowsize, axis=0)
+        y1 = apply_ragged(func, x, rowsize, axis=1)
         self.assertTrue(np.all(y0 == y1.T))
+
+        # Test that axis=1 works with reduction over the non-ragged axis.
+        y = apply_ragged(np.sum, x, rowsize, axis=1)
+        self.assertTrue(np.all(y == np.sum(x, axis=0)))
+
+        # Test that the same works with xr.DataArray as input
+        # (this did not work before the axis feature was added).
+        y = apply_ragged(np.sum, xr.DataArray(data=x), rowsize, axis=1)
+        self.assertTrue(np.all(y == np.sum(x, axis=0)))
+
+        # Test that axis works for multiple outputs:
+        func = lambda x: (np.mean(x), np.std(x))
+        y = apply_ragged(func, x, rowsize, axis=1)
+        self.assertTrue(np.all(y[0] == np.mean(x, axis=0)))
+        self.assertTrue(np.all(y[1] == np.std(x, axis=0)))
 
     def test_velocity_ndarray(self):
         for executor in [futures.ThreadPoolExecutor(), futures.ProcessPoolExecutor()]:

--- a/tests/sphere_tests.py
+++ b/tests/sphere_tests.py
@@ -409,9 +409,3 @@ class coriolis_frequency_tests(unittest.TestCase):
             ]
         )
         self.assertTrue(np.allclose(f, f_expected))
-
-    def test_coriolis_frequency_warning(self):
-        with self.assertWarns(Warning):
-            coriolis_frequency(91)
-        with self.assertWarns(Warning):
-            coriolis_frequency(-91)


### PR DESCRIPTION
This PR:

* Adds `axis` to `apply_ragged` and `unpack_ragged` to specify unpacking/concatenation axis; default is 0, which is consistent with `np.concatenate` and `np.split`.
* Fixes a few edge cases that didn't work before:
  - If you use a reduction function over a non-ragged axis, passing `xr.DataArray`s now works.
  - If you use a reduction function over a non-ragged axis and return more than one result (tuple), concatenation now works.
* Unrelated to this PR, there was an outstanding issue with a test for `coriolis_frequency` that tested for a Warning that shouldn't be there. I don't know why tests were passing on `main` but this was failing for me. It's fixed.
* Minor version bump to 0.23.0

Closes #274.