### PR TITLE
`rotary_transform` -> `cartesian_to_rotary`, `rotary_to_cartesian`

### DIFF
--- a/clouddrift/signal.py
+++ b/clouddrift/signal.py
@@ -194,13 +194,13 @@ def cartesian_to_rotary(
 
     >>> u = np.random.rand(99)
     >>> v = np.random.rand(99)
-    >>> wp, wn = cartesian_to_rotary(analytic_signal(u),analytic_signal(v))
+    >>> wp, wn = cartesian_to_rotary(analytic_signal(u), analytic_signal(v))
 
     To specify that the time axis is along the first axis:
 
-    >>> u = np.random.rand(100,99)
-    >>> v = np.random.rand(100,99)
-    >>> wp, wn = cartesian_to_rotary(analytic_signal(u),analytic_signal(v),time_axis=0)
+    >>> u = np.random.rand(100, 99)
+    >>> v = np.random.rand(100, 99)
+    >>> wp, wn = cartesian_to_rotary(analytic_signal(u), analytic_signal(v), time_axis=0)
 
     Raises
     ------
@@ -215,7 +215,7 @@ def cartesian_to_rotary(
 
     See Also
     --------
-    :func:`analytic_signal`, `rotary_to_cartesian`
+    :func:`analytic_signal`, :func:`rotary_to_cartesian`
     """
     # u and v arrays must have the same shape.
     if not ua.shape == va.shape:
@@ -239,8 +239,8 @@ def rotary_to_cartesian(
     wn: Union[np.ndarray, xr.DataArray],
     time_axis: Optional[int] = -1,
 ) -> Tuple[np.ndarray, np.ndarray]:
-    """Return Cartesian analytic signals (ua,va) from rotary signals (wp,wn) as
-    ua = wp + wn and va = -1j * (wp - wn).
+    """Return Cartesian analytic signals (ua, va) from rotary signals (wp, wn)
+    as ua = wp + wn and va = -1j * (wp - wn).
 
     This function is the inverse of :func:`cartesian_to_rotary`.
 
@@ -270,7 +270,7 @@ def rotary_to_cartesian(
 
     To specify that the time axis is along the first axis:
 
-    >>> ua, va = rotary_to_cartesian(wp,wn,time_axis=0)
+    >>> ua, va = rotary_to_cartesian(wp, wn, time_axis=0)
 
     Raises
     ------
@@ -285,7 +285,7 @@ def rotary_to_cartesian(
 
     See Also
     --------
-    :func:`analytic_signal`, `cartesian_to_rotary`
+    :func:`analytic_signal`, :func:`cartesian_to_rotary`
     """
 
     if not wp.shape == wn.shape:

--- a/clouddrift/signal.py
+++ b/clouddrift/signal.py
@@ -85,7 +85,7 @@ def analytic_signal(
 
     See Also
     --------
-    :func:`rotary_to_cartesian`, `cartesian_to_rotary`
+    :func:`rotary_to_cartesian`, :func:`cartesian_to_rotary`
     """
     # time_axis must be in valid range
     if time_axis < -1 or time_axis > len(x.shape) - 1:

--- a/tests/signal_tests.py
+++ b/tests/signal_tests.py
@@ -1,5 +1,5 @@
 from clouddrift.signal import (
-    analytic_transform,
+    analytic_signal,
     cartesian_to_rotary,
     rotary_to_cartesian,
 )
@@ -11,110 +11,132 @@ if __name__ == "__main__":
     unittest.main()
 
 
-class analytic_transform_tests(unittest.TestCase):
+class analytic_signal_tests(unittest.TestCase):
+    def test_size(self):
+        x = np.random.rand(99)
+        z = analytic_signal(x)
+        self.assertEqual(np.shape(x), np.shape(z))
+
+    def test_imag(self):
+        x = np.random.rand(99) + 1j * np.random.rand(99)
+        z = analytic_signal(x)
+        self.assertTrue(type(z) == tuple)
+
     def test_real_odd(self):
         x = np.random.rand(99)
-        z = analytic_transform(x)
-        self.assertTrue(np.allclose(x - np.mean(x), z.real))
+        z = analytic_signal(x)
+        self.assertTrue(np.allclose(x, z.real))
 
     def test_real_even(self):
         x = np.random.rand(100)
-        z = analytic_transform(x)
-        self.assertTrue(np.allclose(x - np.mean(x), z.real))
+        z = analytic_signal(x)
+        self.assertTrue(np.allclose(x, z.real))
 
     def test_imag_odd(self):
         z = np.random.rand(99) + 1j * np.random.rand(99)
-        zp = analytic_transform(z)
-        zn = analytic_transform(np.conj(z))
-        self.assertTrue(np.allclose(z - np.mean(z, keepdims=True), zp + np.conj(zn)))
+        wp, wn = analytic_signal(z)
+        self.assertTrue(np.allclose(z, wp + np.conj(wn)))
 
     def test_imag_even(self):
         z = np.random.rand(100) + 1j * np.random.rand(100)
-        zp = analytic_transform(z)
-        zn = analytic_transform(np.conj(z))
-        self.assertTrue(np.allclose(z - np.mean(z, keepdims=True), zp + np.conj(zn)))
+        wp, wn = analytic_signal(z)
+        self.assertTrue(np.allclose(z, wp + np.conj(wn)))
 
     def test_boundary(self):
         x = np.random.rand(99)
-        z1 = analytic_transform(x, boundary="mirror")
-        z2 = analytic_transform(x, boundary="zeros")
-        z3 = analytic_transform(x, boundary="periodic")
-        self.assertTrue(np.allclose(x - np.mean(x), z1.real))
-        self.assertTrue(np.allclose(x - np.mean(x), z2.real))
-        self.assertTrue(np.allclose(x - np.mean(x), z3.real))
+        z1 = analytic_signal(x, boundary="mirror")
+        z2 = analytic_signal(x, boundary="zeros")
+        z3 = analytic_signal(x, boundary="periodic")
+        self.assertTrue(np.allclose(x, z1.real))
+        self.assertTrue(np.allclose(x, z2.real))
+        self.assertTrue(np.allclose(x, z3.real))
 
     def test_ndarray(self):
         x = np.random.random((9, 11, 13))
         for n in range(3):
-            z = analytic_transform(x, time_axis=n)
-            self.assertTrue(np.allclose(x - np.mean(x, axis=n, keepdims=True), z.real))
+            z = analytic_signal(x, time_axis=n)
+            self.assertTrue(np.allclose(x, z.real))
 
     def test_xarray(self):
         x = xr.DataArray(data=np.random.random((9, 11, 13)))
         for n in range(3):
-            z = analytic_transform(x, time_axis=n)
-            self.assertTrue(
-                np.allclose(x - np.array(np.mean(x, axis=n, keepdims=True)), z.real)
-            )
+            z = analytic_signal(x, time_axis=n)
+            self.assertTrue(np.allclose(x, z.real))
 
 
 class cartesian_to_rotary_tests(unittest.TestCase):
     def test_size(self):
-        u = np.random.rand(99)
-        v = np.random.rand(99)
-        zp, zn = cartesian_to_rotary(u, v)
-        self.assertEqual(np.shape(u), np.shape(zp))
-        self.assertEqual(np.shape(u), np.shape(zn))
+        ua = np.random.rand(99) + 1j * np.random.rand(99)
+        va = np.random.rand(99) + 1j * np.random.rand(99)
+        wp, wn = cartesian_to_rotary(ua, va)
+        self.assertEqual(np.shape(ua), np.shape(wp))
+        self.assertEqual(np.shape(ua), np.shape(wn))
 
     def test_array(self):
-        u = np.random.random((9))
-        v = np.random.random((9))
-        zp, zn = cartesian_to_rotary(u, v)
-        self.assertTrue(np.allclose(u + 1j * v, zp + np.conj(zn)))
+        ua = np.random.random((99)) + 1j * np.random.random((99))
+        va = np.random.random((99)) + 1j * np.random.random((99))
+        wp, wn = cartesian_to_rotary(ua, va)
+        self.assertTrue(np.allclose(np.real(ua) + 1j * np.real(va), wp + np.conj(wn)))
 
     def test_ndarray(self):
-        u = np.random.rand(99, 10, 101)
-        v = np.random.rand(99, 10, 101)
-        zp, zn = cartesian_to_rotary(u, v)
-        self.assertTrue(np.allclose(u + 1j * v, zp + np.conj(zn)))
+        ua = np.random.rand(99, 10, 101) + 1j * np.random.rand(99, 10, 101)
+        va = np.random.rand(99, 10, 101) + 1j * np.random.rand(99, 10, 101)
+        wp, wn = cartesian_to_rotary(ua, va)
+        self.assertTrue(np.allclose(np.real(ua) + 1j * np.real(va), wp + np.conj(wn)))
 
     def test_xarray(self):
-        u = xr.DataArray(data=np.random.rand(99))
-        v = xr.DataArray(data=np.random.rand(99))
-        zp, zn = cartesian_to_rotary(u, v)
-        self.assertTrue(np.allclose(u + 1j * v, zp + np.conj(zn)))
+        ua = xr.DataArray(data=np.random.rand(99, 100) + 1j * np.random.rand(99, 100))
+        va = xr.DataArray(data=np.random.rand(99, 100) + 1j * np.random.rand(99, 100))
+        wp, wn = cartesian_to_rotary(ua, va)
+        self.assertTrue(np.allclose(np.real(ua) + 1j * np.real(va), wp + np.conj(wn)))
+
+    def test_invert_cartesian_to_rotary(self):
+        u = np.random.rand(99)
+        v = np.random.rand(99)
+        ua = analytic_signal(u)
+        va = analytic_signal(v)
+        wp, wn = cartesian_to_rotary(ua, va)
+        ua_, va_ = rotary_to_cartesian(wp, wn)
+        self.assertTrue(np.allclose(ua, ua_))
+        self.assertTrue(np.allclose(va, va_))
+        self.assertTrue(np.allclose(u, np.real(ua_)))
+        self.assertTrue(np.allclose(v, np.real(va_)))
 
 
 class rotary_to_cartesian_tests(unittest.TestCase):
     def test_size(self):
-        zp = np.random.rand(99)
-        zn = np.random.rand(99)
-        u, v = rotary_to_cartesian(zp, zn)
-        self.assertEqual(np.shape(u), np.shape(zp))
-        self.assertEqual(np.shape(u), np.shape(zn))
+        wp = np.random.rand(99) + 1j * np.random.rand(99)
+        wn = np.random.rand(99) + 1j * np.random.rand(99)
+        ua, va = rotary_to_cartesian(wp, wn)
+        self.assertEqual(np.shape(ua), np.shape(wp))
+        self.assertEqual(np.shape(va), np.shape(wp))
 
     def test_array(self):
-        zp = np.random.random((9))
-        zn = np.random.random((9))
-        u, v = rotary_to_cartesian(zp, zn)
-        self.assertTrue(np.allclose(u + 1j * v, zp + np.conj(zn)))
+        wp = np.random.random((100)) + 1j * np.random.random((100))
+        wn = np.random.random((100)) + 1j * np.random.random((100))
+        ua, va = rotary_to_cartesian(wp, wn)
+        self.assertTrue(np.allclose(np.real(ua) + 1j * np.real(va), wp + np.conj(wn)))
 
     def test_ndarray(self):
-        zp = np.random.rand(99, 10, 101)
-        zn = np.random.rand(99, 10, 101)
-        u, v = rotary_to_cartesian(zp, zn)
-        self.assertTrue(np.allclose(u + 1j * v, zp + np.conj(zn)))
+        wp = np.random.rand(99, 10, 101) + 1j * np.random.rand(99, 10, 101)
+        wn = np.random.rand(99, 10, 101) + 1j * np.random.rand(99, 10, 101)
+        ua, va = rotary_to_cartesian(wp, wn)
+        self.assertTrue(np.allclose(np.real(ua) + 1j * np.real(va), wp + np.conj(wn)))
 
     def test_xarray(self):
-        zp = xr.DataArray(data=np.random.rand(99))
-        zn = xr.DataArray(data=np.random.rand(99))
-        u, v = rotary_to_cartesian(zp, zn)
-        self.assertTrue(np.allclose(u + 1j * v, zp + np.conj(zn)))
+        wp = xr.DataArray(data=np.random.rand(99)) + 1j * xr.DataArray(
+            data=np.random.rand(99)
+        )
+        wn = xr.DataArray(data=np.random.rand(99)) + 1j * xr.DataArray(
+            data=np.random.rand(99)
+        )
+        ua, va = rotary_to_cartesian(wp, wn)
+        self.assertTrue(np.allclose(np.real(ua) + 1j * np.real(va), wp + np.conj(wn)))
 
     def test_invert_rotary_to_cartesian(self):
-        u = np.random.rand(99)
-        v = np.random.rand(99)
-        zp, zn = cartesian_to_rotary(u, v)
-        u_, v_ = rotary_to_cartesian(zp, zn)
-        self.assertTrue(np.allclose(u, u_))
-        self.assertTrue(np.allclose(v, v_))
+        wp = np.random.random((100)) + 1j * np.random.random((100))
+        wn = np.random.random((100)) + 1j * np.random.random((100))
+        ua, va = rotary_to_cartesian(wp, wn)
+        wp_, wn_ = cartesian_to_rotary(ua, va)
+        self.assertTrue(np.allclose(wp, wp_))
+        self.assertTrue(np.allclose(wn, wn_))

--- a/tests/signal_tests.py
+++ b/tests/signal_tests.py
@@ -1,6 +1,7 @@
 from clouddrift.signal import (
     analytic_transform,
-    rotary_transform,
+    cartesian_to_rotary,
+    rotary_to_cartesian,
 )
 import numpy as np
 import unittest
@@ -57,21 +58,63 @@ class analytic_transform_tests(unittest.TestCase):
             )
 
 
-class rotary_transform_tests(unittest.TestCase):
+class cartesian_to_rotary_tests(unittest.TestCase):
+    def test_size(self):
+        u = np.random.rand(99)
+        v = np.random.rand(99)
+        zp, zn = cartesian_to_rotary(u, v)
+        self.assertEqual(np.shape(u), np.shape(zp))
+        self.assertEqual(np.shape(u), np.shape(zn))
+
     def test_array(self):
         u = np.random.random((9))
         v = np.random.random((9))
-        zp, zn = rotary_transform(u, v)
+        zp, zn = cartesian_to_rotary(u, v)
         self.assertTrue(np.allclose(u + 1j * v, zp + np.conj(zn)))
 
     def test_ndarray(self):
         u = np.random.rand(99, 10, 101)
         v = np.random.rand(99, 10, 101)
-        zp, zn = rotary_transform(u, v)
+        zp, zn = cartesian_to_rotary(u, v)
         self.assertTrue(np.allclose(u + 1j * v, zp + np.conj(zn)))
 
     def test_xarray(self):
         u = xr.DataArray(data=np.random.rand(99))
         v = xr.DataArray(data=np.random.rand(99))
-        zp, zn = rotary_transform(u, v)
+        zp, zn = cartesian_to_rotary(u, v)
         self.assertTrue(np.allclose(u + 1j * v, zp + np.conj(zn)))
+
+
+class rotary_to_cartesian_tests(unittest.TestCase):
+    def test_size(self):
+        zp = np.random.rand(99)
+        zn = np.random.rand(99)
+        u, v = rotary_to_cartesian(zp, zn)
+        self.assertEqual(np.shape(u), np.shape(zp))
+        self.assertEqual(np.shape(u), np.shape(zn))
+
+    def test_array(self):
+        zp = np.random.random((9))
+        zn = np.random.random((9))
+        u, v = rotary_to_cartesian(zp, zn)
+        self.assertTrue(np.allclose(u + 1j * v, zp + np.conj(zn)))
+
+    def test_ndarray(self):
+        zp = np.random.rand(99, 10, 101)
+        zn = np.random.rand(99, 10, 101)
+        u, v = rotary_to_cartesian(zp, zn)
+        self.assertTrue(np.allclose(u + 1j * v, zp + np.conj(zn)))
+
+    def test_xarray(self):
+        zp = xr.DataArray(data=np.random.rand(99))
+        zn = xr.DataArray(data=np.random.rand(99))
+        u, v = rotary_to_cartesian(zp, zn)
+        self.assertTrue(np.allclose(u + 1j * v, zp + np.conj(zn)))
+
+    def test_invert_rotary_to_cartesian(self):
+        u = np.random.rand(99)
+        v = np.random.rand(99)
+        zp, zn = cartesian_to_rotary(u, v)
+        u_, v_ = rotary_to_cartesian(zp, zn)
+        self.assertTrue(np.allclose(u, u_))
+        self.assertTrue(np.allclose(v, v_))


### PR DESCRIPTION
This PR renames `signal.rotary_transform` to `cartesian_to_rotary` and introduces `rotary_to_cartesian` as its invert. 

Are we happy with the input/output types? Should we test/allows pandas series as well?