### PR TITLE
Remove redundant coords assignment; test for dims and coords

### DIFF
--- a/clouddrift/adapters/glad.py
+++ b/clouddrift/adapters/glad.py
@@ -63,9 +63,10 @@ def to_xarray() -> xr.Dataset:
     # Make the dataset compatible with clouddrift functions.
     ds = (
         ds.swap_dims({"index": "obs"})
+        .drop_vars(["id", "index"])
         .assign_coords(traj=traj)
         .assign({"rowsize": ("traj", rowsize)})
-        .drop_vars(["id", "index"])
+        .rename_vars({"obs": "time", "traj": "id"})
     )
 
     # Cast double floats to singles

--- a/clouddrift/adapters/glad.py
+++ b/clouddrift/adapters/glad.py
@@ -63,7 +63,7 @@ def to_xarray() -> xr.Dataset:
     # Make the dataset compatible with clouddrift functions.
     ds = (
         ds.swap_dims({"index": "obs"})
-        .assign_coords(obs=ds.obs, traj=traj)
+        .assign_coords(traj=traj)
         .assign({"rowsize": ("traj", rowsize)})
         .drop_vars(["id", "index"])
     )

--- a/clouddrift/datasets.py
+++ b/clouddrift/datasets.py
@@ -153,8 +153,8 @@ def glad() -> xr.Dataset:
     <xarray.Dataset>
     Dimensions:         (obs: 1602883, traj: 297)
     Coordinates:
-      * obs             (obs) datetime64[ns] 2012-07-20T01:15:00.143960 ... 2012-...
-      * traj            (traj) object 'CARTHE_001' 'CARTHE_002' ... 'CARTHE_451'
+      * time            (obs) datetime64[ns] 2012-07-20T01:15:00.143960 ... 2012-...
+      * id              (traj) object 'CARTHE_001' 'CARTHE_002' ... 'CARTHE_451'
     Data variables:
       latitude        (obs) float32 28.56 28.56 28.56 28.56 ... 26.33 26.33 26.33
       longitude       (obs) float32 -87.21 -87.21 -87.21 ... -87.09 -87.09 -87.08

--- a/tests/datasets_tests.py
+++ b/tests/datasets_tests.py
@@ -27,12 +27,12 @@ class datasets_tests(unittest.TestCase):
         self.assertTrue("obs" in ds.dims)
         self.assertTrue("traj" in ds.dims)
         self.assertTrue(len(ds.coords) == 2)
-        self.assertTrue("obs" in ds.coords)
-        self.assertTrue("traj" in ds.coords)
+        self.assertTrue("time" in ds.coords)
+        self.assertTrue("id" in ds.coords)
 
     def test_glad_subset_and_apply_ragged_work(self):
         ds = datasets.glad()
-        ds_sub = subset(ds, {"traj": ["CARTHE_001", "CARTHE_002"]}, id_var_name="traj")
+        ds_sub = subset(ds, {"id": ["CARTHE_001", "CARTHE_002"]}, id_var_name="id")
         self.assertTrue(ds_sub)
         mean_lon = apply_ragged(np.mean, [ds_sub.longitude], ds_sub.rowsize)
         self.assertTrue(mean_lon.size == 2)

--- a/tests/datasets_tests.py
+++ b/tests/datasets_tests.py
@@ -21,6 +21,15 @@ class datasets_tests(unittest.TestCase):
         ds = datasets.glad()
         self.assertTrue(ds)
 
+    def test_glad_dims_coords(self):
+        ds = datasets.glad()
+        self.assertTrue(len(ds.dims) == 2)
+        self.assertTrue("obs" in ds.dims)
+        self.assertTrue("traj" in ds.dims)
+        self.assertTrue(len(ds.coords) == 2)
+        self.assertTrue("obs" in ds.coords)
+        self.assertTrue("traj" in ds.coords)
+
     def test_glad_subset_and_apply_ragged_work(self):
         ds = datasets.glad()
         ds_sub = subset(ds, {"traj": ["CARTHE_001", "CARTHE_002"]}, id_var_name="traj")


### PR DESCRIPTION
I don't know why this fixes this `index` dim on some systems, but it seems like it does. I added tests to ensure that only `obs` and `traj` are in dims and coords.

@selipot @philippemiron please check on your ends.

Closes #323.