### PR TITLE
Datasets consistency

### DIFF
--- a/clouddrift/datasets.py
+++ b/clouddrift/datasets.py
@@ -29,7 +29,7 @@ def gdp1h() -> xr.Dataset:
     <xarray.Dataset>
     Dimensions:                (traj: 19396, obs: 197214787)
     Coordinates:
-        ids                    (obs) int64 ...
+        id                     (traj) int64 ...
         time                   (obs) float64 ...
     Dimensions without coordinates: traj, obs
     Data variables: (12/60)
@@ -66,7 +66,9 @@ def gdp1h() -> xr.Dataset:
     :func:`gdp6h`
     """
     url = "https://noaa-oar-hourly-gdp-pds.s3.amazonaws.com/latest/gdp-v2.01.zarr"
-    return xr.open_dataset(url, engine="zarr", decode_times=False)
+    ds = xr.open_dataset(url, engine="zarr", decode_times=False)
+    ds = ds.rename_vars({"ID": "id"}).assign_coords({"id": ds.ID}).drop_vars(["ids"])
+    return ds
 
 
 def gdp6h() -> xr.Dataset:
@@ -90,13 +92,12 @@ def gdp6h() -> xr.Dataset:
     <xarray.Dataset>
     Dimensions:                (traj: 26843, obs: 44544647)
     Coordinates:
-        ids                    (obs) int64 ...
+        id                     (traj) int64 ...
         time                   (obs) float64 ...
         lon                    (obs) float32 ...
         lat                    (obs) float32 ...
     Dimensions without coordinates: traj, obs
     Data variables: (12/44)
-        ID                     (traj) int64 ...
         rowsize                (traj) int32 ...
         WMO                    (traj) int32 ...
         expno                  (traj) int32 ...
@@ -129,7 +130,9 @@ def gdp6h() -> xr.Dataset:
     :func:`gdp1h`
     """
     url = "https://www.aoml.noaa.gov/ftp/pub/phod/buoydata/gdp_jul22_ragged_6h.nc#mode=bytes"
-    return xr.open_dataset(url, decode_times=False)
+    ds = xr.open_dataset(url, decode_times=False)
+    ds = ds.rename_vars({"ID": "id"}).assign_coords({"id": ds.ID}).drop_vars(["ids"])
+    return ds
 
 
 def glad() -> xr.Dataset:

--- a/clouddrift/datasets.py
+++ b/clouddrift/datasets.py
@@ -188,7 +188,8 @@ def glad() -> xr.Dataset:
         ds.to_netcdf(glad_path)
     else:
         ds = xr.open_dataset(glad_path)
-    ds["time"] = _to_seconds_since_epoch(ds["time"])
+    if not ds["time"].dtype == float:
+        ds["time"] = _to_seconds_since_epoch(ds["time"])
     return ds
 
 
@@ -254,7 +255,8 @@ def mosaic() -> xr.Dataset:
         ds.to_netcdf(mosaic_path)
     else:
         ds = xr.open_dataset(mosaic_path)
-    ds["time"] = _to_seconds_since_epoch(ds["time"])
+    if not ds["time"].dtype == float:
+        ds["time"] = _to_seconds_since_epoch(ds["time"])
     return ds
 
 
@@ -343,7 +345,8 @@ def subsurface_floats() -> xr.Dataset:
         ds.to_netcdf(local_file)
     else:
         ds = xr.open_dataset(local_file)
-    ds["time"] = _to_seconds_since_epoch(ds["time"])
+    if not ds["time"].dtype == float:
+        ds["time"] = _to_seconds_since_epoch(ds["time"])
     return ds
 
 

--- a/clouddrift/ragged.py
+++ b/clouddrift/ragged.py
@@ -539,7 +539,7 @@ def segment(
 def subset(
     ds: xr.Dataset,
     criteria: dict,
-    id_var_name: str = "ID",
+    id_var_name: str = "id",
     rowsize_var_name: str = "rowsize",
     traj_dim_name: str = "traj",
     obs_dim_name: str = "obs",
@@ -561,7 +561,7 @@ def subset(
     criteria : dict
         dictionary containing the variables and the ranges/values to subset
     id_var_name : str, optional
-        Name of the variable containing the ID of the trajectories (default is "ID")
+        Name of the variable containing the ID of the trajectories (default is "id")
     rowsize_var_name : str, optional
         Name of the variable containing the number of observations per trajectory (default is "rowsize")
     traj_dim_name : str, optional
@@ -601,7 +601,7 @@ def subset(
 
     Retrieve specific drifters from their IDs:
 
-    >>> subset(ds, {"ID": [2578, 2582, 2583]})
+    >>> subset(ds, {"id": [2578, 2582, 2583]})
 
     Retrieve a specific time period:
 

--- a/docs/datasets.rst
+++ b/docs/datasets.rst
@@ -67,12 +67,12 @@ Currently available datasets are:
   hosted by NOAA AOML at 
   `NOAA's Atlantic Oceanographic and Meteorological Laboratory (AOML) <https://www.aoml.noaa.gov/phod/float_traj/index.php>_`
   and maintained by Andree Ramsey and Heather Furey from the Woods Hole Oceanographic Institution.
-- :func:`clouddrift.datasets.spotters`: The SOFAR ocean spotters archive dataset as hosted at the public `AWS S3 bucket <https://sofar-spotter-archive.s3.amazonaws.com/spotter_data_bulk_zarr>`_.
+- :func:`clouddrift.datasets.spotters`: The Sofar Ocean Spotters archive dataset as hosted at the public `AWS S3 bucket <https://sofar-spotter-archive.s3.amazonaws.com/spotter_data_bulk_zarr>`_.
 - :func:`clouddrift.datasets.yomaha`: The YoMaHa'07 dataset as a ragged array
   processed from the upstream dataset hosted at the `Asia-Pacific Data-Research
   Center (APDRC) <http://apdrc.soest.hawaii.edu/projects/yomaha/>`_.
 
-The GDP nd the spotters datasets are accessed lazily, so the data is only downloaded when
-specific array values are referenced. The ANDRO, GLAD, MOSAiC, Subsurface floats, and YoMaHa'07
+The GDP and the Spotters datasets are accessed lazily, so the data is only downloaded when
+specific array values are referenced. The ANDRO, GLAD, MOSAiC, Subsurface Floats, and YoMaHa'07
 datasets are downloaded in their entirety when the function is called for the first 
 time and stored locally for later use.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clouddrift"
-version = "0.28.0"
+version = "0.28.1"
 authors = [
   { name="Shane Elipot", email="selipot@miami.edu" },
   { name="Philippe Miron", email="philippemiron@gmail.com" },

--- a/tests/datasets_tests.py
+++ b/tests/datasets_tests.py
@@ -9,17 +9,20 @@ if __name__ == "__main__":
 
 
 class datasets_tests(unittest.TestCase):
-    def test_gdp1h_opens(self):
+    def test_gdp1h(self):
         ds = datasets.gdp1h()
         self.assertTrue(ds)
+        self.assertTrue(ds["time"].dtype == float)
 
-    def test_gdp6h_opens(self):
+    def test_gdp6h(self):
         ds = datasets.gdp6h()
         self.assertTrue(ds)
+        self.assertTrue(ds["time"].dtype == float)
 
-    def test_glad_opens(self):
+    def test_glad(self):
         ds = datasets.glad()
         self.assertTrue(ds)
+        self.assertTrue(ds["time"].dtype == float)
 
     def test_glad_dims_coords(self):
         ds = datasets.glad()
@@ -40,3 +43,4 @@ class datasets_tests(unittest.TestCase):
     def test_subsurface_floats_opens(self):
         ds = datasets.subsurface_floats()
         self.assertTrue(ds)
+        self.assertTrue(ds["time"].dtype == float)

--- a/tests/datasets_tests.py
+++ b/tests/datasets_tests.py
@@ -12,17 +12,14 @@ class datasets_tests(unittest.TestCase):
     def test_gdp1h(self):
         ds = datasets.gdp1h()
         self.assertTrue(ds)
-        self.assertTrue(ds["time"].dtype == float)
 
     def test_gdp6h(self):
         ds = datasets.gdp6h()
         self.assertTrue(ds)
-        self.assertTrue(ds["time"].dtype == float)
 
     def test_glad(self):
         ds = datasets.glad()
         self.assertTrue(ds)
-        self.assertTrue(ds["time"].dtype == float)
 
     def test_glad_dims_coords(self):
         ds = datasets.glad()

--- a/tests/pairs_tests.py
+++ b/tests/pairs_tests.py
@@ -21,7 +21,7 @@ class pairs_chance_pairs_from_ragged_tests(unittest.TestCase):
 
     def test_chance_pairs_from_ragged(self):
         space_distance = 10000
-        time_distance = 0
+        time_distance = np.timedelta64(0)
         chance_pairs = pairs.chance_pairs_from_ragged(
             self.lon,
             self.lat,
@@ -60,7 +60,7 @@ class pairs_chance_pair_tests(unittest.TestCase):
 
     def test_chance_pair(self):
         space_distance = 6000
-        time_distance = 0
+        time_distance = np.timedelta64(0)
         i1, i2 = pairs.chance_pair(
             self.lon1,
             self.lat1,

--- a/tests/pairs_tests.py
+++ b/tests/pairs_tests.py
@@ -21,7 +21,7 @@ class pairs_chance_pairs_from_ragged_tests(unittest.TestCase):
 
     def test_chance_pairs_from_ragged(self):
         space_distance = 10000
-        time_distance = np.timedelta64(0)
+        time_distance = 0
         chance_pairs = pairs.chance_pairs_from_ragged(
             self.lon,
             self.lat,
@@ -60,7 +60,7 @@ class pairs_chance_pair_tests(unittest.TestCase):
 
     def test_chance_pair(self):
         space_distance = 6000
-        time_distance = np.timedelta64(0)
+        time_distance = 0
         i1, i2 = pairs.chance_pair(
             self.lon1,
             self.lat1,

--- a/tests/ragged_tests.py
+++ b/tests/ragged_tests.py
@@ -42,7 +42,7 @@ def sample_ragged_array() -> RaggedArray:
     variables_coords = ["ids", "time", "lon", "lat"]
 
     coords = {"lon": longitude, "lat": latitude, "ids": ids, "time": t}
-    metadata = {"ID": drifter_id, "rowsize": rowsize}
+    metadata = {"id": drifter_id, "rowsize": rowsize}
     data = {"test": test}
 
     # append xr.Dataset to a list
@@ -79,7 +79,7 @@ def sample_ragged_array() -> RaggedArray:
         [0, 1, 2],
         lambda i: list_ds[i],
         variables_coords,
-        ["ID", "rowsize"],
+        ["id", "rowsize"],
         ["test"],
     )
 
@@ -584,12 +584,12 @@ class subset_tests(unittest.TestCase):
 
     def test_equal(self):
         ds_sub = subset(self.ds, {"test": True})
-        self.assertEqual(len(ds_sub.ID), 2)
+        self.assertEqual(len(ds_sub.id), 2)
 
     def test_select(self):
-        ds_sub = subset(self.ds, {"ID": [1, 2]})
-        self.assertTrue(all(ds_sub.ID == [1, 2]))
-        self.assertEqual(len(ds_sub.ID), 2)
+        ds_sub = subset(self.ds, {"id": [1, 2]})
+        self.assertTrue(all(ds_sub.id == [1, 2]))
+        self.assertEqual(len(ds_sub.id), 2)
 
     def test_range(self):
         # positive
@@ -608,27 +608,27 @@ class subset_tests(unittest.TestCase):
         # negative range
         ds_sub = subset(self.ds, {"lon": (-180, 0)})
         traj_idx = np.insert(np.cumsum(ds_sub["rowsize"].values), 0, 0)
-        self.assertEqual(len(ds_sub.ID), 1)
-        self.assertEqual(ds_sub.ID[0], 1)
+        self.assertEqual(len(ds_sub.id), 1)
+        self.assertEqual(ds_sub.id[0], 1)
         self.assertTrue(all(ds_sub.lon == [-121, -111]))
 
         # both
         ds_sub = subset(self.ds, {"lon": (-30, 30)})
         traj_idx = np.insert(np.cumsum(ds_sub["rowsize"].values), 0, 0)
-        self.assertEqual(len(ds_sub.ID), 1)
-        self.assertEqual(ds_sub.ID[0], 2)
+        self.assertEqual(len(ds_sub.id), 1)
+        self.assertEqual(ds_sub.id[0], 2)
         self.assertTrue(all(ds_sub.lon[slice(traj_idx[0], traj_idx[1])] == ([12, 22])))
 
     def test_combine(self):
         ds_sub = subset(
-            self.ds, {"ID": [1, 2], "lat": (-90, 20), "lon": (-180, 25), "test": True}
+            self.ds, {"id": [1, 2], "lat": (-90, 20), "lon": (-180, 25), "test": True}
         )
-        self.assertTrue(all(ds_sub.ID == [1, 2]))
+        self.assertTrue(all(ds_sub.id == [1, 2]))
         self.assertTrue(all(ds_sub.lon == [-121, -111, 12]))
         self.assertTrue(all(ds_sub.lat == [-90, -45, 10]))
 
     def test_empty(self):
-        ds_sub = subset(self.ds, {"ID": 3, "lon": (-180, 0)})
+        ds_sub = subset(self.ds, {"id": 3, "lon": (-180, 0)})
         self.assertTrue(ds_sub.dims == {})
 
     def test_unknown_var(self):
@@ -640,43 +640,43 @@ class subset_tests(unittest.TestCase):
 
     def test_ragged_array_with_id_as_str(self):
         ds_str = self.ds.copy()
-        ds_str["ID"].values = ds_str["ID"].astype(str)
+        ds_str["id"].values = ds_str["id"].astype(str)
 
-        ds_sub = subset(ds_str, {"ID": ds_str["ID"].values[0]})
-        self.assertTrue(ds_sub["ID"].size == 1)
+        ds_sub = subset(ds_str, {"id": ds_str["id"].values[0]})
+        self.assertTrue(ds_sub["id"].size == 1)
 
-        ds_sub = subset(ds_str, {"ID": list(ds_str["ID"].values[:2])})
-        self.assertTrue(ds_sub["ID"].size == 2)
+        ds_sub = subset(ds_str, {"id": list(ds_str["id"].values[:2])})
+        self.assertTrue(ds_sub["id"].size == 2)
 
     def test_ragged_array_with_id_as_object(self):
         ds_str = self.ds.copy()
-        ds_str["ID"].values = ds_str["ID"].astype(object)
+        ds_str["id"].values = ds_str["id"].astype(object)
 
-        ds_sub = subset(ds_str, {"ID": ds_str["ID"].values[0]})
-        self.assertTrue(ds_sub["ID"].size == 1)
+        ds_sub = subset(ds_str, {"id": ds_str["id"].values[0]})
+        self.assertTrue(ds_sub["id"].size == 1)
 
-        ds_sub = subset(ds_str, {"ID": list(ds_str["ID"].values[:2])})
-        self.assertTrue(ds_sub["ID"].size == 2)
+        ds_sub = subset(ds_str, {"id": list(ds_str["id"].values[:2])})
+        self.assertTrue(ds_sub["id"].size == 2)
 
     def test_arraylike_criterion(self):
         # DataArray
-        ds_sub = subset(self.ds, {"ID": self.ds["ID"][:2]})
-        self.assertTrue(ds_sub["ID"].size == 2)
+        ds_sub = subset(self.ds, {"id": self.ds["id"][:2]})
+        self.assertTrue(ds_sub["id"].size == 2)
 
         # NumPy array
-        ds_sub = subset(self.ds, {"ID": self.ds["ID"][:2].values})
-        self.assertTrue(ds_sub["ID"].size == 2)
+        ds_sub = subset(self.ds, {"id": self.ds["id"][:2].values})
+        self.assertTrue(ds_sub["id"].size == 2)
 
     def test_full_trajectories(self):
         ds_id_rowsize = {
-            i: j for i, j in zip(self.ds.ID.values, self.ds.rowsize.values)
+            i: j for i, j in zip(self.ds.id.values, self.ds.rowsize.values)
         }
 
         ds_sub = subset(self.ds, {"lon": (-125, -111)}, full_trajectories=True)
         self.assertTrue(all(ds_sub.lon == [-121, -111, 51, 61, 71]))
 
         ds_sub_id_rowsize = {
-            i: j for i, j in zip(ds_sub.ID.values, ds_sub.rowsize.values)
+            i: j for i, j in zip(ds_sub.id.values, ds_sub.rowsize.values)
         }
         for k, v in ds_sub_id_rowsize.items():
             self.assertTrue(ds_id_rowsize[k] == v)
@@ -685,7 +685,7 @@ class subset_tests(unittest.TestCase):
         self.assertTrue(all(ds_sub.lat == [10, 20, 30, 40]))
 
         ds_sub_id_rowsize = {
-            i: j for i, j in zip(ds_sub.ID.values, ds_sub.rowsize.values)
+            i: j for i, j in zip(ds_sub.id.values, ds_sub.rowsize.values)
         }
         for k, v in ds_sub_id_rowsize.items():
             self.assertTrue(ds_id_rowsize[k] == v)


### PR DESCRIPTION
This PR:

* [x] Ensure all times are decoded by default and let the user choose not to decode (closes #287)
* [x] Removes `ids` and applies `id(traj)` as a coordinate to GDP hourly and 6-hourly (closes #326)
* [x] Changes the default value of `id_var_name` from `"ID"` to `"id"` in `ragged.subset`.
* [ ] ~Updates docs/usage.rst to reflect these changes~.
* [x] Bumps version to 0.29.0.

Adapters are not affected. If time needs to be converted at the adapters level, please use `clouddrift.datasets._to_seconds_since_epoch()`.