### PR TITLE
Subset by rows and pruning examples in docstring

### DIFF
--- a/clouddrift/ragged.py
+++ b/clouddrift/ragged.py
@@ -599,6 +599,12 @@ def subset(
 
     >>> subset(ds, {"sst": (303.15, np.inf)})
 
+    You can use the same approach to return only the trajectories that are
+    shorter than some number of observations (similar to :func:`prune` but for
+    the entire dataset):
+
+    >>> subset(ds, {"rowsize": (0, 1000)})
+
     Retrieve specific drifters from their IDs:
 
     >>> subset(ds, {"ID": [2578, 2582, 2583]})

--- a/clouddrift/ragged.py
+++ b/clouddrift/ragged.py
@@ -610,10 +610,11 @@ def subset(
     >>> subset(ds, {"ID": [2578, 2582, 2583]})
 
     Sometimes, you may want to retrieve specific rows of a ragged array.
-    The easiest way to do that is to slice the "ID" variable:
+    You can do that by querying the trajectory dimension directly, since
+    the dimension data are equivalent to row numbers:
 
     >>> rows = [5, 6, 7]
-    >>> subset(ds, {"ID": ds["ID"][rows]})
+    >>> subset(ds, {"traj": rows})
 
     Retrieve a specific time period:
 
@@ -641,7 +642,7 @@ def subset(
     )
 
     for key in criteria.keys():
-        if key in ds:
+        if key in ds or key in ds.dims:
             if ds[key].dims == (traj_dim_name,):
                 mask_traj = np.logical_and(mask_traj, _mask_var(ds[key], criteria[key]))
             elif ds[key].dims == (obs_dim_name,):

--- a/clouddrift/ragged.py
+++ b/clouddrift/ragged.py
@@ -610,8 +610,8 @@ def subset(
     >>> subset(ds, {"ID": [2578, 2582, 2583]})
 
     Sometimes, you may want to retrieve specific rows of a ragged array.
-    You can do that by querying the trajectory dimension directly, since
-    the dimension data are equivalent to row numbers:
+    You can do that by filtering along the trajectory dimension directly, since
+    this one corresponds to row numbers:
 
     >>> rows = [5, 6, 7]
     >>> subset(ds, {"traj": rows})

--- a/clouddrift/ragged.py
+++ b/clouddrift/ragged.py
@@ -603,6 +603,12 @@ def subset(
 
     >>> subset(ds, {"ID": [2578, 2582, 2583]})
 
+    Sometimes, you may want to retrieve specific rows of a ragged array.
+    The easiest way to do that is to slice the "ID" variable:
+
+    >>> rows = [5, 6, 7]
+    >>> subset(ds, {"ID": ds["ID"][rows]})
+
     Retrieve a specific time period:
 
     >>> subset(ds, {"time": (np.datetime64("2000-01-01"), np.datetime64("2020-01-31"))})

--- a/tests/ragged_tests.py
+++ b/tests/ragged_tests.py
@@ -693,6 +693,12 @@ class subset_tests(unittest.TestCase):
         ds_sub = subset(self.ds, {"time": (4, 5)}, full_trajectories=True)
         xr.testing.assert_equal(self.ds, ds_sub)
 
+    def test_subset_by_rows(self):
+        rows = [0, 2]  # test extracting first and third rows
+        ds_sub = subset(self.ds, {"traj": rows})
+        self.assertTrue(all(ds_sub["ID"] == [1, 2]))
+        self.assertTrue(all(ds_sub["rowsize"] == [5, 4]))
+
 
 class unpack_tests(unittest.TestCase):
     def test_unpack(self):


### PR DESCRIPTION
Not a feature but examples in docstring.

Closes #196.
Closes #305.

After looking into how to do this more easily (see #305 for the problem), I found that it doesn't warrant new functionality, e.g. `rows` keyword parameter. We merely need to slice the `id` array by the desired rows.