### PR TITLE
fix deprecation warnings in tests

### DIFF
--- a/clouddrift/adapters/gdp.py
+++ b/clouddrift/adapters/gdp.py
@@ -311,7 +311,7 @@ def rowsize(index: int, **kwargs) -> int:
             decode_times=False,
             concat_characters=False,
             decode_coords=False,
-        ).dims["obs"]
+        ).sizes["obs"]
     except Exception as e:
         print(
             f"Error processing {os.path.join(kwargs['tmp_path'], kwargs['filename_pattern'].format(id=index))}"

--- a/clouddrift/adapters/gdp1h.py
+++ b/clouddrift/adapters/gdp1h.py
@@ -219,7 +219,7 @@ def preprocess(index: int, **kwargs) -> xr.Dataset:
             warnings.warn(f"Variable {var} not found in upstream data; skipping.")
 
     # new variables
-    ds["ids"] = (["traj", "obs"], [np.repeat(ds.ID.values, ds.dims["obs"])])
+    ds["ids"] = (["traj", "obs"], [np.repeat(ds.ID.values, ds.sizes["obs"])])
     ds["drogue_status"] = (
         ["traj", "obs"],
         [gdp.drogue_presence(ds.drogue_lost_date.data, ds.time.data[0])],

--- a/clouddrift/adapters/gdp6h.py
+++ b/clouddrift/adapters/gdp6h.py
@@ -192,7 +192,7 @@ def preprocess(index: int, **kwargs) -> xr.Dataset:
             warnings.warn(f"Variable {var} not found in upstream data; skipping.")
 
     # new variables
-    ds["ids"] = (["traj", "obs"], [np.repeat(ds.ID.values, ds.dims["obs"])])
+    ds["ids"] = (["traj", "obs"], [np.repeat(ds.ID.values, ds.sizes["obs"])])
     ds["drogue_status"] = (
         ["traj", "obs"],
         [gdp.drogue_presence(ds.drogue_lost_date.data, ds.time.data[0])],

--- a/clouddrift/ragged.py
+++ b/clouddrift/ragged.py
@@ -622,10 +622,10 @@ def subset(
         If one of the variable in a criterion is not found in the Dataset
     """
     mask_traj = xr.DataArray(
-        data=np.ones(ds.dims[traj_dim_name], dtype="bool"), dims=[traj_dim_name]
+        data=np.ones(ds.sizes[traj_dim_name], dtype="bool"), dims=[traj_dim_name]
     )
     mask_obs = xr.DataArray(
-        data=np.ones(ds.dims[obs_dim_name], dtype="bool"), dims=[obs_dim_name]
+        data=np.ones(ds.sizes[obs_dim_name], dtype="bool"), dims=[obs_dim_name]
     )
 
     for key in criteria.keys():

--- a/clouddrift/raggedarray.py
+++ b/clouddrift/raggedarray.py
@@ -107,7 +107,7 @@ class RaggedArray:
         rowsize_func = (
             rowsize_func
             if rowsize_func
-            else lambda i, **kwargs: preprocess_func(i, **kwargs).dims["obs"]
+            else lambda i, **kwargs: preprocess_func(i, **kwargs).sizes["obs"]
         )
         rowsize = cls.number_of_observations(rowsize_func, indices, **kwargs)
         coords, metadata, data = cls.allocate(
@@ -197,16 +197,16 @@ class RaggedArray:
             attrs_variables[var] = ds[var].attrs
 
         for var in ds.data_vars.keys():
-            if len(ds[var]) == ds.dims[dim_traj]:
+            if len(ds[var]) == ds.sizes[dim_traj]:
                 metadata[var] = ds[var].data
-            elif len(ds[var]) == ds.dims[dim_obs]:
+            elif len(ds[var]) == ds.sizes[dim_obs]:
                 data[var] = ds[var].data
             else:
                 warnings.warn(
                     f"""
                     Variable '{var}' has unknown dimension size of 
-                    {len(ds[var])}, which is not traj={ds.dims[dim_traj]} or 
-                    obs={ds.dims[dim_obs]}; skipping.
+                    {len(ds[var])}, which is not traj={ds.sizes[dim_traj]} or 
+                    obs={ds.sizes[dim_obs]}; skipping.
                     """
                 )
             attrs_variables[var] = ds[var].attrs

--- a/clouddrift/sphere.py
+++ b/clouddrift/sphere.py
@@ -649,7 +649,12 @@ def cartesian_to_spherical(
     y /= R
     z /= R
 
-    lon = recast_lon180(np.rad2deg(np.imag(np.log((x + 1j * y)))))
+    with np.errstate(invalid="ignore"):
+        lon = np.where(
+            np.logical_and(x == 0, y == 0),
+            0,
+            recast_lon180(np.rad2deg(np.imag(np.log((x + 1j * y))))),
+        )
     lat = np.rad2deg(np.arcsin(z))
 
     return lon, lat

--- a/clouddrift/sphere.py
+++ b/clouddrift/sphere.py
@@ -649,7 +649,7 @@ def cartesian_to_spherical(
     y /= R
     z /= R
 
-    with np.errstate(invalid="ignore"):
+    with np.errstate(divide="ignore"):
         lon = np.where(
             np.logical_and(x == 0, y == 0),
             0,

--- a/clouddrift/wavelet.py
+++ b/clouddrift/wavelet.py
@@ -187,7 +187,7 @@ def morse_wavelet_transform(
             )
         wtx = wtx_p, wtx_n
 
-    elif ~complex:
+    elif not complex:
         # real case
         wtx = wavelet_transform(x, wavelet, boundary=boundary, time_axis=time_axis)
 

--- a/clouddrift/wavelet.py
+++ b/clouddrift/wavelet.py
@@ -583,12 +583,12 @@ def morse_freq(
     --------
     :func:`morse_wavelet`, :func:`morse_amplitude`
     """
-    # add test for type and shape in case of ndarray?
-    fm = np.where(
-        beta == 0,
-        np.log(2) ** (1 / gamma),
-        np.exp((1 / gamma) * (np.log(beta) - np.log(gamma))),
-    )
+    with np.errstate(divide="ignore"):  # ignore warning when beta=0
+        fm = np.where(
+            beta == 0,
+            np.log(2) ** (1 / gamma),
+            np.exp((1 / gamma) * (np.log(beta) - np.log(gamma))),
+        )
 
     fe = (
         1
@@ -682,7 +682,7 @@ def morse_logspace_freq(
     low_ = np.max(np.append(low, lowset[1]))
 
     r = 1 + 1 / (density * width)
-    m = np.floor(np.log10(high_ / low_) / np.log10(r))
+    m = np.floor(np.log10(high_ / low_) / np.log10(r)).astype(int)[0]
     radian_frequency = high_ * np.ones(int(m + 1)) / r ** np.arange(0, m + 1)
 
     return radian_frequency

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -92,7 +92,7 @@ contiguous 1-dimensional array in memory.
 
 Let's look at the dataset dimensions:
 
->>> ds.dims
+>>> ds.sizes
 Frozen({'traj': 17324, 'obs': 165754333})
 
 The ``traj`` dimension has 17324 elements, which is the number of individual

--- a/tests/datasets_tests.py
+++ b/tests/datasets_tests.py
@@ -23,7 +23,7 @@ class datasets_tests(unittest.TestCase):
 
     def test_glad_dims_coords(self):
         ds = datasets.glad()
-        self.assertTrue(len(ds.dims) == 2)
+        self.assertTrue(len(ds.sizes) == 2)
         self.assertTrue("obs" in ds.dims)
         self.assertTrue("traj" in ds.dims)
         self.assertTrue(len(ds.coords) == 2)

--- a/tests/ragged_tests.py
+++ b/tests/ragged_tests.py
@@ -629,7 +629,7 @@ class subset_tests(unittest.TestCase):
 
     def test_empty(self):
         ds_sub = subset(self.ds, {"ID": 3, "lon": (-180, 0)})
-        self.assertTrue(ds_sub.dims == {})
+        self.assertTrue(ds_sub.sizes == {})
 
     def test_unknown_var(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
Should fix #263 and I also removed the warnings that shows up if `beta=0` in:
```
with np.errstate(divide="ignore"):  # ignore warning when beta=0
        fm = np.where(
            beta == 0,
            np.log(2) ** (1 / gamma),
            np.exp((1 / gamma) * (np.log(beta) - np.log(gamma))),
        )
```

I couldn't see the deprecation warnings on my side, but I guess we want to have `m` as in integer, and not an array.

I also went ahead and fix some other warnings.