### PR TITLE
ruff linting and formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: environment.yml

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
         os: ["ubuntu-latest"]
         python-version: ["3.9"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: mamba-org/setup-micromamba@v1
       with:
         environment-file: environment.yml

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,7 @@ on:
   release:
     types:
       - published
-  
+
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,7 +29,7 @@ jobs:
         pip install -r requirements.txt
         make html
     - name: Upload HTML artificat
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: DocumentationHTML
         path: docs/_build/html/

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,5 +14,5 @@ jobs:
   ruff:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: chartboost/ruff-action@v1

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,10 +7,12 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
 
 jobs:
-  lint:
+  ruff:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: psf/black@stable
+      - uses: chartboost/ruff-action@v1

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: 3.9
@@ -40,7 +40,7 @@ jobs:
           else
             echo "Looks good"
           fi
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: releases
           path: dist
@@ -51,11 +51,11 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         name: Install Python
         with:
           python-version: 3.9
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: releases
           path: dist
@@ -82,7 +82,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: releases
           path: dist

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.repository == 'Cloud-Drift/clouddrift'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: actions/setup-python@v4

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -72,7 +72,7 @@ jobs:
         if: github.event_name == 'push'
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/
           verbose: true
 
   upload-to-pypi:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Cloud-Drift/clouddrift-examples/main?labpath=notebooks)
 [![Available on conda-forge](https://anaconda.org/conda-forge/clouddrift/badges/version.svg?style=flat-square)](https://anaconda.org/conda-forge/clouddrift/)
 [![Available on pypi](https://img.shields.io/pypi/v/clouddrift.svg?style=flat-square&color=blue)](https://pypi.org/project/clouddrift/)
-[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+[![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![NSF-2126413](https://img.shields.io/badge/NSF-2126413-blue.svg)](https://nsf.gov/awardsearch/showAward?AWD_ID=2126413)
 [![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2FCloud-Drift%2Fclouddrift&count_bg=%2368C563&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=hits&edge_flat=false)](https://hits.seeyoufarm.com)
 

--- a/clouddrift/__init__.py
+++ b/clouddrift/__init__.py
@@ -2,13 +2,26 @@ from ._version import version
 
 __version__ = version
 
+import clouddrift.adapters as adapters
+import clouddrift.datasets as datasets
+import clouddrift.kinematics as kinematics
+import clouddrift.pairs as pairs
+import clouddrift.plotting as plotting
+import clouddrift.ragged as ragged
+import clouddrift.signal as signal
+import clouddrift.sphere as sphere
+import clouddrift.wavelet as wavelet
 from clouddrift.raggedarray import RaggedArray
-import clouddrift.adapters
-import clouddrift.datasets
-import clouddrift.kinematics
-import clouddrift.pairs
-import clouddrift.plotting
-import clouddrift.ragged
-import clouddrift.signal
-import clouddrift.sphere
-import clouddrift.wavelet
+
+__all__ = [
+    "RaggedArray",
+    "adapters",
+    "datasets",
+    "kinematics",
+    "pairs",
+    "plotting",
+    "ragged",
+    "signal",
+    "sphere",
+    "wavelet",
+]

--- a/clouddrift/adapters/__init__.py
+++ b/clouddrift/adapters/__init__.py
@@ -14,9 +14,8 @@ import clouddrift.adapters.gdp6h as gdp6h
 import clouddrift.adapters.glad as glad
 import clouddrift.adapters.mosaic as mosaic
 import clouddrift.adapters.subsurface_floats as subsurface_floats
-import clouddrift.adapters.yomaha as yomaha
 import clouddrift.adapters.utils as utils
-
+import clouddrift.adapters.yomaha as yomaha
 
 __all__ = [
     "andro",

--- a/clouddrift/adapters/andro.py
+++ b/clouddrift/adapters/andro.py
@@ -17,14 +17,16 @@ Kolodziejczyk Nicolas (2022). ANDRO: An Argo-based deep displacement dataset.
 SEANOE. https://doi.org/10.17882/47077
 """
 
-from clouddrift.adapters.utils import download_with_progress
-from datetime import datetime
-import numpy as np
 import os
-import pandas as pd
 import tempfile
-import xarray as xr
 import warnings
+from datetime import datetime
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
+from clouddrift.adapters.utils import download_with_progress
 
 # order of the URLs is important
 ANDRO_URL = "https://www.seanoe.org/data/00360/47077/data/91950.dat"

--- a/clouddrift/adapters/gdp.py
+++ b/clouddrift/adapters/gdp.py
@@ -5,11 +5,13 @@ defined in this module are common to both hourly (``clouddrift.adapters.gdp1h``)
 and six-hourly (``clouddrift.adapters.gdp6h``) GDP modules.
 """
 
-from clouddrift.adapters.utils import download_with_progress
-import numpy as np
 import os
+
+import numpy as np
 import pandas as pd
 import xarray as xr
+
+from clouddrift.adapters.utils import download_with_progress
 
 GDP_COORDS = [
     "ids",
@@ -148,7 +150,8 @@ def get_gdp_metadata() -> pd.DataFrame:
         try:
             dfs.append(parse_directory_file(name))
             start += 5000
-        except:
+        except Exception as e:
+            print(f"Error reading metadata for file: '{name}', error: {e}")
             break
 
     name = directory_file_pattern.format(low=start, high="current")

--- a/clouddrift/adapters/gdp1h.py
+++ b/clouddrift/adapters/gdp1h.py
@@ -4,18 +4,20 @@ hourly Global Drifter Program (GDP) data to a ``clouddrift.RaggedArray``
 instance.
 """
 
-import clouddrift.adapters.gdp as gdp
-from clouddrift.raggedarray import RaggedArray
-from clouddrift.adapters.utils import download_with_progress
-from datetime import datetime, timedelta
-import numpy as np
-import urllib.request
+import os
 import re
 import tempfile
-from typing import Optional
-import os
+import urllib.request
 import warnings
+from datetime import datetime, timedelta
+from typing import Optional
+
+import numpy as np
 import xarray as xr
+
+import clouddrift.adapters.gdp as gdp
+from clouddrift.adapters.utils import download_with_progress
+from clouddrift.raggedarray import RaggedArray
 
 GDP_VERSION = "2.01"
 

--- a/clouddrift/adapters/gdp6h.py
+++ b/clouddrift/adapters/gdp6h.py
@@ -4,18 +4,20 @@ This module provides functions and metadata that can be used to convert the
 instance.
 """
 
+import os
+import re
+import tempfile
+import urllib.request
+import warnings
+from datetime import datetime, timedelta
+from typing import Optional
+
+import numpy as np
+import xarray as xr
+
 import clouddrift.adapters.gdp as gdp
 from clouddrift.adapters.utils import download_with_progress
 from clouddrift.raggedarray import RaggedArray
-from datetime import datetime, timedelta
-import numpy as np
-import urllib.request
-import re
-import tempfile
-from typing import Optional
-import os
-import warnings
-import xarray as xr
 
 GDP_VERSION = "September 2023"
 

--- a/clouddrift/adapters/glad.py
+++ b/clouddrift/adapters/glad.py
@@ -13,12 +13,13 @@ Reference
 ---------
 Özgökmen, Tamay. 2013. GLAD experiment CODE-style drifter trajectories (low-pass filtered, 15 minute interval records), northern Gulf of Mexico near DeSoto Canyon, July-October 2012. Distributed by: Gulf of Mexico Research Initiative Information and Data Cooperative (GRIIDC), Harte Research Institute, Texas A&M University–Corpus Christi. doi:10.7266/N7VD6WC8
 """
-
-from clouddrift.adapters.utils import download_with_progress
 from io import BytesIO
+
 import numpy as np
 import pandas as pd
 import xarray as xr
+
+from clouddrift.adapters.utils import download_with_progress
 
 
 def get_dataframe() -> pd.DataFrame:
@@ -28,7 +29,7 @@ def get_dataframe() -> pd.DataFrame:
     # the expected data length here.
     file_size = 155330876
     buf = BytesIO(b"")
-    download_with_progress([(url, buf)])
+    download_with_progress([(url, buf, file_size)])
     buf.seek(0)
     column_names = [
         "id",

--- a/clouddrift/adapters/mosaic.py
+++ b/clouddrift/adapters/mosaic.py
@@ -18,15 +18,14 @@ Example
 >>> from clouddrift.adapters import mosaic
 >>> ds = mosaic.to_xarray()
 """
-
+import xml.etree.ElementTree as ET
 from datetime import datetime
 from io import BytesIO
+
 import numpy as np
 import pandas as pd
 import requests
-from tqdm import tqdm
 import xarray as xr
-import xml.etree.ElementTree as ET
 
 from clouddrift.adapters.utils import download_with_progress
 

--- a/clouddrift/adapters/subsurface_floats.py
+++ b/clouddrift/adapters/subsurface_floats.py
@@ -11,14 +11,15 @@ Example
 >>> ds = subsurface_floats.to_xarray()
 """
 
-from datetime import datetime
-import numpy as np
 import os
+import tempfile
+import warnings
+from datetime import datetime
+
+import numpy as np
 import pandas as pd
 import scipy.io
-import tempfile
 import xarray as xr
-import warnings
 
 from clouddrift.adapters.utils import download_with_progress
 
@@ -180,7 +181,7 @@ def to_xarray(
         "publisher_name": "WOCE Subsurface Float Data Assembly Center and NOAA AOML",
         "publisher_url": "https://www.aoml.noaa.gov/phod/float_traj/data.php",
         "license": "freely available",
-        "acknowledgement": f"Maintained by Andree Ramsey and Heather Furey from the Woods Hole Oceanographic Institution",
+        "acknowledgement": "Maintained by Andree Ramsey and Heather Furey from the Woods Hole Oceanographic Institution",
     }
 
     # set attributes

--- a/clouddrift/adapters/utils.py
+++ b/clouddrift/adapters/utils.py
@@ -38,11 +38,14 @@ def download_with_progress(
                 executor.submit(
                     _download_with_progress, src, dst, exp_size, prewrite_func
                 )
-            ] = src
+            ] = (src, dst)
 
         for fut in concurrent.futures.as_completed(futures):
-            url = futures[fut]
-            print(f"Finished downloading: {url}")
+            (src, dst) = futures[fut]
+            ex = fut.exception(0)
+            if ex is not None:
+                print(f"there was an issue downloading {src} to {dst}, exception details: {ex}")
+            print(f"Finished downloading: {src}")
 
 
 @retry(

--- a/clouddrift/adapters/utils.py
+++ b/clouddrift/adapters/utils.py
@@ -20,7 +20,7 @@ _CHUNK_SIZE = 1024
 class _DownloadRequest(NamedTuple):
     src: str
     dst: Union[BufferedIOBase, str]
-    exp_size: Union[int, None]
+    exp_size: Union[float, None]
 
 
 def download_with_progress(
@@ -55,6 +55,7 @@ def download_with_progress(
 def _download_with_progress(
     url: str,
     output: Union[BufferedIOBase, str],
+    expected_size: Union[float, None],
     prewrite_func: Callable[[bytes], Union[str, bytes]],
 ):
     if isinstance(output, str) and os.path.exists(output):
@@ -90,7 +91,7 @@ def _download_with_progress(
             buffer = output
         bar = tqdm(
             desc=url,
-            total=int(response.headers.get("Content-Length", 0)),
+            total=float(response.headers.get("Content-Length", expected_size)),
             unit="B",
             unit_scale=True,
             unit_divisor=1024,

--- a/clouddrift/adapters/yomaha.py
+++ b/clouddrift/adapters/yomaha.py
@@ -16,17 +16,17 @@ Reference
 Lebedev, K. V., Yoshinari, H., Maximenko, N. A., & Hacker, P. W. (2007). Velocity data assessed from trajectories of Argo floats at parking level and at the sea surface. IPRC Technical Note, 4(2), 1-16.
 """
 
-from datetime import datetime
 import gzip
-import numpy as np
 import os
-import pandas as pd
 import tempfile
-import xarray as xr
 import warnings
+from datetime import datetime
+
+import numpy as np
+import pandas as pd
+import xarray as xr
 
 from clouddrift.adapters.utils import download_with_progress
-
 
 YOMAHA_URLS = [
     # order of the URLs is important

--- a/clouddrift/datasets.py
+++ b/clouddrift/datasets.py
@@ -4,12 +4,13 @@ not accessed via cloud storage platforms or are not found on the local filesyste
 they will be downloaded from their upstream repositories and stored for later access 
 (~/.clouddrift for UNIX-based systems).
 """
-
-from io import BufferedReader, BytesIO
-from clouddrift import adapters
 import os
 import platform
+from io import BufferedReader, BytesIO
+
 import xarray as xr
+
+from clouddrift import adapters
 
 
 def gdp1h(decode_times: bool = True) -> xr.Dataset:

--- a/clouddrift/kinematics.py
+++ b/clouddrift/kinematics.py
@@ -2,10 +2,12 @@
 Functions for kinematic computations.
 """
 
+from typing import Optional, Tuple, Union
+
 import numpy as np
 import pandas as pd
-from typing import Optional, Tuple, Union
 import xarray as xr
+
 from clouddrift.sphere import (
     EARTH_RADIUS_METERS,
     bearing,
@@ -466,7 +468,7 @@ def position_from_velocity(
     if time_axis < -1 or time_axis > len(u.shape) - 1:
         raise ValueError(
             f"time_axis ({time_axis}) is outside of the valid range ([-1,"
-            f" {len(x.shape) - 1}])."
+            f" {len(u.shape) - 1}])."
         )
 
     # Input arrays must have the same length along the time axis.

--- a/clouddrift/pairs.py
+++ b/clouddrift/pairs.py
@@ -1,14 +1,15 @@
 """
 Functions to analyze pairs of contiguous data segments.
 """
-
-from clouddrift import ragged, sphere
-from concurrent.futures import as_completed, ThreadPoolExecutor
 import itertools
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import List, Optional, Tuple, Union
+
 import numpy as np
 import pandas as pd
 import xarray as xr
-from typing import List, Optional, Tuple, Union
+
+from clouddrift import ragged, sphere
 
 array_like = Union[list[float], np.ndarray[float], pd.Series, xr.DataArray]
 
@@ -338,12 +339,14 @@ def pair_bounding_box_overlap(
     # First get the bounding box of each trajectory.
     # We unwrap the longitudes before computing min/max because we want to
     # consider trajectories that cross the dateline.
-    lon1_min, lon1_max = np.min(np.unwrap(lon1, period=360)), np.max(
-        np.unwrap(lon1, period=360)
+    lon1_min, lon1_max = (
+        np.min(np.unwrap(lon1, period=360)),
+        np.max(np.unwrap(lon1, period=360)),
     )
     lat1_min, lat1_max = np.min(lat1), np.max(lat1)
-    lon2_min, lon2_max = np.min(np.unwrap(lon2, period=360)), np.max(
-        np.unwrap(lon2, period=360)
+    lon2_min, lon2_max = (
+        np.min(np.unwrap(lon2, period=360)),
+        np.max(np.unwrap(lon2, period=360)),
     )
     lat2_min, lat2_max = np.min(lat2), np.max(lat2)
 

--- a/clouddrift/plotting.py
+++ b/clouddrift/plotting.py
@@ -2,14 +2,13 @@
 This module provides a function to easily and efficiently plot trajectories stored in a ragged array.
 """
 
-from clouddrift.ragged import segment, rowsize_to_index
+from typing import Optional, Union
+
 import numpy as np
 import pandas as pd
-from typing import Optional, Union
 import xarray as xr
-import pandas as pd
-from typing import Optional, Union
-from clouddrift.ragged import segment, rowsize_to_index
+
+from clouddrift.ragged import rowsize_to_index, segment
 
 
 def plot_ragged(
@@ -130,10 +129,10 @@ def plot_ragged(
 
     # optional dependency
     try:
-        import matplotlib.pyplot as plt
         import matplotlib.colors as mcolors
-        from matplotlib.collections import LineCollection
+        import matplotlib.pyplot as plt
         from matplotlib import cm
+        from matplotlib.collections import LineCollection
     except ImportError:
         raise ImportError("missing optional dependency 'matplotlib'")
 

--- a/clouddrift/ragged.py
+++ b/clouddrift/ragged.py
@@ -2,13 +2,14 @@
 Transformational and inquiry functions for ragged arrays.
 """
 
-import numpy as np
-from typing import Tuple, Union, Iterable, Callable
-import xarray as xr
-import pandas as pd
+import warnings
 from concurrent import futures
 from datetime import timedelta
-import warnings
+from typing import Callable, Iterable, Tuple, Union
+
+import numpy as np
+import pandas as pd
+import xarray as xr
 
 
 def apply_ragged(

--- a/clouddrift/raggedarray.py
+++ b/clouddrift/raggedarray.py
@@ -3,15 +3,16 @@ This module defines the RaggedArray class, which is the intermediate data
 structure used by CloudDrift to process custom Lagrangian datasets to Xarray
 Datasets and Awkward Arrays.
 """
+import warnings
+from collections.abc import Callable
+from typing import Optional, Tuple
 
 import awkward as ak
-from clouddrift.ragged import rowsize_to_index
-import xarray as xr
 import numpy as np
-from collections.abc import Callable
-from typing import Tuple, Optional
+import xarray as xr
 from tqdm import tqdm
-import warnings
+
+from clouddrift.ragged import rowsize_to_index
 
 
 class RaggedArray:

--- a/clouddrift/signal.py
+++ b/clouddrift/signal.py
@@ -2,8 +2,9 @@
 This module provides signal processing functions.
 """
 
-import numpy as np
 from typing import Optional, Tuple, Union
+
+import numpy as np
 import xarray as xr
 
 

--- a/clouddrift/sphere.py
+++ b/clouddrift/sphere.py
@@ -2,10 +2,11 @@
 This module provides functions for spherical geometry calculations.
 """
 
-import numpy as np
-from typing import Optional, Tuple, Union
-import xarray as xr
 import warnings
+from typing import Optional, Tuple, Union
+
+import numpy as np
+import xarray as xr
 
 EARTH_RADIUS_METERS = 6.3781e6
 EARTH_DAY_SECONDS = 86164.091

--- a/clouddrift/wavelet.py
+++ b/clouddrift/wavelet.py
@@ -15,9 +15,11 @@ Any other code that is added to this module and that is specific to Python and
 not the MATLAB implementation is licensed under CloudDrift's MIT license.
 """
 
-import numpy as np
 from typing import Optional, Tuple, Union
-from scipy.special import gamma as _gamma, gammaln as _lgamma
+
+import numpy as np
+from scipy.special import gamma as _gamma
+from scipy.special import gammaln as _lgamma
 
 
 def morse_wavelet_transform(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,3 +40,7 @@ dependencies = [
 [project.urls]
 Homepage = "https://github.com/Cloud-Drift/clouddrift"
 Documentation = "https://cloud-drift.github.io/clouddrift"
+
+[tool.ruff.lint]
+ignore = ["E731", "E741"]
+select = ["E4", "E7", "E9", "F", "I"]

--- a/tests/datasets_tests.py
+++ b/tests/datasets_tests.py
@@ -1,8 +1,9 @@
-from clouddrift import datasets
-from clouddrift.ragged import apply_ragged, subset
-import numpy as np
 import unittest
 
+import numpy as np
+
+from clouddrift import datasets
+from clouddrift.ragged import apply_ragged, subset
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/kinematics_tests.py
+++ b/tests/kinematics_tests.py
@@ -1,17 +1,18 @@
+import unittest
+
+import numpy as np
+import xarray as xr
+
 from clouddrift.kinematics import (
     inertial_oscillation_from_position,
     kinetic_energy,
     position_from_velocity,
     residual_position_from_displacement,
-    velocity_from_position,
     spin,
+    velocity_from_position,
 )
-from clouddrift.sphere import EARTH_RADIUS_METERS, coriolis_frequency
 from clouddrift.raggedarray import RaggedArray
-import unittest
-import numpy as np
-import xarray as xr
-
+from clouddrift.sphere import EARTH_RADIUS_METERS, coriolis_frequency
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/pairs_tests.py
+++ b/tests/pairs_tests.py
@@ -1,9 +1,10 @@
-from clouddrift import datasets, pairs, ragged, sphere
+import unittest
+
 import numpy as np
 import pandas as pd
-import unittest
 import xarray as xr
 
+from clouddrift import datasets, pairs, ragged, sphere
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/plotting_tests.py
+++ b/tests/plotting_tests.py
@@ -1,11 +1,12 @@
-import cartopy.crs as ccrs
-import matplotlib.pyplot as plt
-import numpy as np
 import sys
 import unittest
 from unittest.mock import patch
-from clouddrift.plotting import plot_ragged
 
+import cartopy.crs as ccrs
+import matplotlib.pyplot as plt
+import numpy as np
+
+from clouddrift.plotting import plot_ragged
 
 if __name__ == "__main__":
     unittest.main()
@@ -56,13 +57,13 @@ class plotting_tests(unittest.TestCase):
         ax = fig.add_subplot(1, 1, 1)
         color_test = np.append(np.arange(len(self.lat)), 3)
         with self.assertRaises(ValueError):
-            l = plot_ragged(ax, self.lon, self.lat, self.rowsize, colors=color_test)
+            plot_ragged(ax, self.lon, self.lat, self.rowsize, colors=color_test)
 
     def test_plot_cartopy_transform(self):
         fig = plt.figure()
         ax = fig.add_subplot(1, 1, 1, projection=ccrs.PlateCarree())
         with self.assertRaises(ValueError):
-            l = plot_ragged(
+            plot_ragged(
                 ax,
                 self.lon,
                 self.lat,
@@ -141,8 +142,9 @@ class plotting_tests(unittest.TestCase):
     def test_matplotlib_not_installed(self):
         try:
             del sys.modules["clouddrift.plotting"]
-        except:
-            pass
+        except Exception as e:
+            print(f"Could not delete module for testing purposes, error: {e}")
+
         with patch.dict(sys.modules, {"matplotlib": None}):
             with self.assertRaises(ImportError):
                 from clouddrift.plotting import plot_ragged

--- a/tests/ragged_tests.py
+++ b/tests/ragged_tests.py
@@ -1,3 +1,11 @@
+import unittest
+from concurrent import futures
+from datetime import datetime, timedelta
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+
 from clouddrift.kinematics import velocity_from_position
 from clouddrift.ragged import (
     apply_ragged,
@@ -10,14 +18,6 @@ from clouddrift.ragged import (
     unpack,
 )
 from clouddrift.raggedarray import RaggedArray
-from clouddrift.sphere import EARTH_RADIUS_METERS
-import unittest
-import numpy as np
-import xarray as xr
-import pandas as pd
-from datetime import datetime, timedelta
-from concurrent import futures
-
 
 if __name__ == "__main__":
     unittest.main()
@@ -565,7 +565,7 @@ class apply_ragged_tests(unittest.TestCase):
     def test_bad_rowsize_raises(self):
         with self.assertRaises(ValueError):
             for use_threads in [True, False]:
-                y = apply_ragged(
+                apply_ragged(
                     lambda x: x**2,
                     np.array([1, 2, 3, 4]),
                     [2],
@@ -579,7 +579,7 @@ class subset_tests(unittest.TestCase):
 
     def test_ds_unmodified(self):
         ds_original = self.ds.copy(deep=True)
-        ds_sub = subset(self.ds, {"test": True})
+        subset(self.ds, {"test": True})
         xr.testing.assert_equal(ds_original, self.ds)
 
     def test_equal(self):
@@ -758,7 +758,7 @@ class unpack_tests(unittest.TestCase):
         # Test unpacking into DataArrays
         lon = unpack(ds.lon, ds["rowsize"])
 
-        self.assertTrue(type(lon) is list)
+        self.assertTrue(isinstance(lon, list))
         self.assertTrue(np.all([type(a) is xr.DataArray for a in lon]))
         self.assertTrue(
             np.all([lon[n].size == ds["rowsize"][n] for n in range(len(lon))])
@@ -767,7 +767,7 @@ class unpack_tests(unittest.TestCase):
         # Test unpacking into np.ndarrays
         lon = unpack(ds.lon.values, ds["rowsize"])
 
-        self.assertTrue(type(lon) is list)
+        self.assertTrue(isinstance(lon, list))
         self.assertTrue(np.all([type(a) is np.ndarray for a in lon]))
         self.assertTrue(
             np.all([lon[n].size == ds["rowsize"][n] for n in range(len(lon))])

--- a/tests/raggedarray_tests.py
+++ b/tests/raggedarray_tests.py
@@ -1,10 +1,12 @@
+import os
 import unittest
 from unittest import TestCase
-import os
-import xarray as xr
-import numpy as np
-from clouddrift import RaggedArray
+
 import awkward as ak
+import numpy as np
+import xarray as xr
+
+from clouddrift import RaggedArray
 
 NETCDF_ARCHIVE = "test_archive.nc"
 PARQUET_ARCHIVE = "test_archive.parquet"
@@ -42,24 +44,24 @@ class raggedarray_tests(TestCase):
             xr_coords["ids"] = (
                 ["obs"],
                 np.ones(self.rowsize[i], dtype="int") * self.drifter_id[i],
-                {"long_name": f"variable ids", "units": "-"},
+                {"long_name": "variable ids", "units": "-"},
             )
 
             xr_data = {}
             xr_data["ID"] = (
                 ["traj"],
                 [self.drifter_id[i]],
-                {"long_name": f"variable ID", "units": "-"},
+                {"long_name": "variable ID", "units": "-"},
             )
             xr_data["rowsize"] = (
                 ["traj"],
                 [self.rowsize[i]],
-                {"long_name": f"variable rowsize", "units": "-"},
+                {"long_name": "variable rowsize", "units": "-"},
             )
             xr_data["temp"] = (
                 ["obs"],
                 np.random.rand(self.rowsize[i]),
-                {"long_name": f"variable temp", "units": "-"},
+                {"long_name": "variable temp", "units": "-"},
             )
 
             list_ds.append(

--- a/tests/signal_tests.py
+++ b/tests/signal_tests.py
@@ -1,13 +1,15 @@
+import unittest
+
+import numpy as np
+import xarray as xr
+
 from clouddrift.signal import (
     analytic_signal,
     cartesian_to_rotary,
-    rotary_to_cartesian,
     ellipse_parameters,
     modulated_ellipse_signal,
+    rotary_to_cartesian,
 )
-import numpy as np
-import unittest
-import xarray as xr
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/sphere_tests.py
+++ b/tests/sphere_tests.py
@@ -1,23 +1,25 @@
+import unittest
+
+import numpy as np
+import xarray as xr
+
 from clouddrift.sphere import (
-    recast_lon,
-    recast_lon180,
-    recast_lon360,
-    plane_to_sphere,
-    sphere_to_plane,
-    distance,
+    EARTH_RADIUS_METERS,
     bearing,
-    position_from_distance_and_bearing,
-    spherical_to_cartesian,
     cartesian_to_spherical,
-    tangentplane_to_cartesian,
     cartesian_to_tangentplane,
     coriolis_frequency,
     cumulative_distance,
-    EARTH_RADIUS_METERS,
+    distance,
+    plane_to_sphere,
+    position_from_distance_and_bearing,
+    recast_lon,
+    recast_lon180,
+    recast_lon360,
+    sphere_to_plane,
+    spherical_to_cartesian,
+    tangentplane_to_cartesian,
 )
-import unittest
-import numpy as np
-import xarray as xr
 
 ONE_DEGREE_METERS = np.deg2rad(EARTH_RADIUS_METERS)
 

--- a/tests/wavelet_tests.py
+++ b/tests/wavelet_tests.py
@@ -1,15 +1,17 @@
+import unittest
+
+import numpy as np
+
 from clouddrift.wavelet import (
-    morse_wavelet_transform,
-    wavelet_transform,
-    morse_wavelet,
-    morse_freq,
+    _morsehigh,
     morse_amplitude,
+    morse_freq,
     morse_logspace_freq,
     morse_properties,
-    _morsehigh,
+    morse_wavelet,
+    morse_wavelet_transform,
+    wavelet_transform,
 )
-import numpy as np
-import unittest
 
 if __name__ == "__main__":
     unittest.main()
@@ -190,7 +192,6 @@ class wavelet_transform_tests(unittest.TestCase):
         omega = dt * 2 * np.pi * f
         a = 1
         x = a * np.cos(2 * np.pi * t * f)
-        z = a * np.exp(1j * 2 * np.pi * t * f) + a / 2 * np.exp(-1j * 2 * np.pi * t * f)
         gamma = 3
         beta = 10
         waveletb, _ = morse_wavelet(


### PR DESCRIPTION
* fix linting errors (pyflakes) - Caught a couple small bugs here and there, unused variables and the likes
* sort imports (isort) - consistently sorted imports. Stdlib imports first then external dependencies then our package imports.
* format code against (pycodestyles) - Fairly similar to the formatting with black but gives us control over styling while using black we do rely a bit on the style black prefers.