### PR TITLE
🔧 update retry config and keep completed downloads

### DIFF
--- a/clouddrift/adapters/utils.py
+++ b/clouddrift/adapters/utils.py
@@ -23,7 +23,7 @@ _standard_retry_protocol: Callable[[WrappedFn], WrappedFn] = retry(
     retry=retry_if_exception(
         lambda ex: isinstance(ex, (requests.Timeout, requests.HTTPError))
     ),
-    wait=wait_exponential_jitter(initial=1.25),
+    wait=wait_exponential_jitter(initial=1.25), # ~ 20-25 minutes total time before completely failing
     stop=stop_after_attempt(10),
     before=lambda rcs: _logger.debug(
         f"calling {str(rcs.fn)}, attempt: {rcs.attempt_number}"
@@ -80,9 +80,10 @@ def download_with_progress(
         )
         for x in futures.keys():
             (src, dst) = futures[x]
-            if isinstance(dst, (str,)) and os.path.exists(dst):
+            if isinstance(dst, (str,)) and os.path.exists(dst) and not x.done():
                 os.remove(dst)
-            x.cancel()
+            if not x.done():
+                x.cancel()
         raise e
     finally:
         executor.shutdown(True)

--- a/clouddrift/adapters/utils.py
+++ b/clouddrift/adapters/utils.py
@@ -23,7 +23,7 @@ _standard_retry_protocol: Callable[[WrappedFn], WrappedFn] = retry(
     retry=retry_if_exception(
         lambda ex: isinstance(ex, (requests.Timeout, requests.HTTPError))
     ),
-    wait=wait_exponential_jitter(initial=0.25),
+    wait=wait_exponential_jitter(initial=1.25),
     stop=stop_after_attempt(10),
     before=lambda rcs: _logger.debug(
         f"calling {str(rcs.fn)}, attempt: {rcs.attempt_number}"

--- a/tests/adapters/utils_tests.py
+++ b/tests/adapters/utils_tests.py
@@ -205,7 +205,7 @@ class utils_tests(unittest.TestCase):
             self.gen_future_mock(),
             self.gen_future_mock(),
             self.gen_future_mock(Exception("just a test exception that is expected")),
-            self.gen_future_mock(),
+            self.gen_future_mock(complete=True),
         ]
 
         futures_mock = Mock()
@@ -235,12 +235,14 @@ class utils_tests(unittest.TestCase):
             )
             assert tpe_mock.submit.call_count == len(mocked_futures)
             assert self.bar_mock.update.call_count == 2
-            assert os_mock.remove.call_count == len(mocked_futures)
+            assert os_mock.remove.call_count == len(mocked_futures) - 1
             tpe_mock.shutdown.assert_called_once()
-            [fut_mock.cancel.assert_called_once() for fut_mock in mocked_futures]
+            [fut_mock.cancel.assert_called_once() for fut_mock in mocked_futures[:-1]]
+            mocked_futures[-1].cancel.assert_not_called()
 
-    def gen_future_mock(self, ex=None):
+    def gen_future_mock(self, ex=None, complete=False):
         future = Mock()
         future.exception = Mock(return_value=ex)
+        future.done = Mock(return_value=complete)
         future.cancel = Mock()
         return future


### PR DESCRIPTION
I believe the retry logic we had before hand was a bit to aggresive resulting again and again in failed downloads. This makes the logic a lot more forgiving.

Before hand the max retry using the description provided [here](https://tenacity.readthedocs.io/en/latest/api.html#tenacity.wait.wait_exponential_jitter) 