### PR TITLE
 🔧  update codecov action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
               coverage xml
       - name: Upload coverage report to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           file: ./coverage.xml
   doctest:


### PR DESCRIPTION
Just bump the codecov action version after seeing the warning at the bottom [here](https://github.com/Cloud-Drift/clouddrift/actions/runs/8649847347).