### PR TITLE
🔧  show progress for downloads configurable for testing

### DIFF
--- a/clouddrift/adapters/utils.py
+++ b/clouddrift/adapters/utils.py
@@ -17,7 +17,7 @@ from tenacity import (
 )
 from tqdm import tqdm
 
-_DEFAULT_SHOW_PROGRESS = True # purely to de-noise our test suite output, should never be used/configured outside of that.
+_DISABLE_SHOW_PROGRESS = False # purely to de-noise our test suite output, should never be used/configured outside of that.
 
 
 def _before_call(rcs: RetryCallState):
@@ -50,7 +50,7 @@ def download_with_progress(
     custom_retry_protocol: Callable[[WrappedFn], WrappedFn] | None = None,
 ):
     if show_list_progress is None:
-        show_list_progress = _DEFAULT_SHOW_PROGRESS and len(download_map) > 20
+        show_list_progress = len(download_map) > 20
     if custom_retry_protocol is None:
         retry_protocol = _standard_retry_protocol
     else:
@@ -67,12 +67,12 @@ def download_with_progress(
                 src,
                 dst,
                 exp_size or 0,
-                _DEFAULT_SHOW_PROGRESS and not show_list_progress,
+                not show_list_progress,
             )
         ] = (src, dst)
     try:
         if show_list_progress:
-            bar = tqdm(desc=desc, total=len(futures), unit="Files")
+            bar = tqdm(desc=desc, total=len(futures), unit="Files", disable=_DISABLE_SHOW_PROGRESS)
 
         for fut in concurrent.futures.as_completed(futures):
             (src, dst) = futures[fut]
@@ -151,6 +151,7 @@ def _download_with_progress(
                 unit_scale=True,
                 unit_divisor=1024,
                 nrows=2,
+                disable=_DISABLE_SHOW_PROGRESS
             )
 
         for chunk in response.iter_content(_CHUNK_SIZE):

--- a/clouddrift/adapters/utils.py
+++ b/clouddrift/adapters/utils.py
@@ -17,6 +17,8 @@ from tenacity import (
 )
 from tqdm import tqdm
 
+_DEFAULT_SHOW_PROGRESS = True # purely to de-noise our test suite output, should never be used/configured outside of that.
+
 
 def _before_call(rcs: RetryCallState):
     if rcs.attempt_number > 1:
@@ -48,7 +50,7 @@ def download_with_progress(
     custom_retry_protocol: Callable[[WrappedFn], WrappedFn] | None = None,
 ):
     if show_list_progress is None:
-        show_list_progress = len(download_map) > 20
+        show_list_progress = _DEFAULT_SHOW_PROGRESS and len(download_map) > 20
     if custom_retry_protocol is None:
         retry_protocol = _standard_retry_protocol
     else:
@@ -65,7 +67,7 @@ def download_with_progress(
                 src,
                 dst,
                 exp_size or 0,
-                not show_list_progress,
+                _DEFAULT_SHOW_PROGRESS and not show_list_progress,
             )
         ] = (src, dst)
     try:

--- a/clouddrift/raggedarray.py
+++ b/clouddrift/raggedarray.py
@@ -18,6 +18,7 @@ from tqdm import tqdm
 from clouddrift.ragged import rowsize_to_index
 
 DimNames = Literal["rows", "obs"]
+_DISABLE_SHOW_PROGRESS = False # purely to de-noise our test suite output, should never be used/configured outside of that.
 
 
 class RaggedArray:
@@ -296,6 +297,7 @@ class RaggedArray:
             total=len(indices),
             desc="Retrieving the number of obs",
             ncols=80,
+            disable=_DISABLE_SHOW_PROGRESS
         ):
             rowsize[i] = rowsize_func(index, **kwargs)
         return rowsize
@@ -418,6 +420,7 @@ class RaggedArray:
             total=len(indices),
             desc="Filling the Ragged Array",
             ncols=80,
+            disable=_DISABLE_SHOW_PROGRESS
         ):
             with preprocess_func(index, **kwargs) as ds:
                 size = rowsize[i]

--- a/tests/adapters/gdp1h_integ_tests.py
+++ b/tests/adapters/gdp1h_integ_tests.py
@@ -1,21 +1,13 @@
 import os
 import shutil
-import unittest
 
 import numpy as np
 
-from clouddrift.adapters import gdp1h, utils
+import tests.utils as testutils
+from clouddrift.adapters import gdp1h
 
 
-class gdp1h_integration_tests(unittest.TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        utils._DEFAULT_SHOW_PROGRESS = False
-
-    def tearDown(self) -> None:
-        super().tearDown()
-        utils._DEFAULT_SHOW_PROGRESS = True
-
+class gdp1h_integration_tests(testutils.DisableProgressTestCase):
     def test_load_subset_and_create_aggregate(self):
         test_tasks = [
             (gdp1h.GDP_TMP_PATH, gdp1h.GDP_DATA_URL),

--- a/tests/adapters/gdp1h_integ_tests.py
+++ b/tests/adapters/gdp1h_integ_tests.py
@@ -4,10 +4,18 @@ import unittest
 
 import numpy as np
 
-from clouddrift.adapters import gdp1h
+from clouddrift.adapters import gdp1h, utils
 
 
 class gdp1h_integration_tests(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        utils._DEFAULT_SHOW_PROGRESS = False
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        utils._DEFAULT_SHOW_PROGRESS = True
+
     def test_load_subset_and_create_aggregate(self):
         test_tasks = [
             (gdp1h.GDP_TMP_PATH, gdp1h.GDP_DATA_URL),

--- a/tests/adapters/gdp6h_integ_tests.py
+++ b/tests/adapters/gdp6h_integ_tests.py
@@ -1,16 +1,13 @@
-import logging
 import os
 import shutil
-import unittest
 
 import numpy as np
 
+import tests.utils as testutils
 from clouddrift.adapters import gdp6h, utils
 
-_logger = logging.getLogger(__name__)
 
-
-class gdp6h_integration_tests(unittest.TestCase):
+class gdp6h_integration_tests(testutils.DisableProgressTestCase):
     def setUp(self) -> None:
         super().setUp()
         utils._DEFAULT_SHOW_PROGRESS = False
@@ -20,7 +17,6 @@ class gdp6h_integration_tests(unittest.TestCase):
         utils._DEFAULT_SHOW_PROGRESS = True
 
     def test_load_subset_and_create_aggregate(self):
-        _logger.info("test gdp6h adapter, load, subset and create aggregate")
         ra = gdp6h.to_raggedarray(n_random_id=5, tmp_path=gdp6h.GDP_TMP_PATH)
         assert "rowsize" in ra.metadata
         assert "temp" in ra.data

--- a/tests/adapters/gdp6h_integ_tests.py
+++ b/tests/adapters/gdp6h_integ_tests.py
@@ -1,14 +1,26 @@
+import logging
 import os
 import shutil
 import unittest
 
 import numpy as np
 
-from clouddrift.adapters import gdp6h
+from clouddrift.adapters import gdp6h, utils
+
+_logger = logging.getLogger(__name__)
 
 
 class gdp6h_integration_tests(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        utils._DEFAULT_SHOW_PROGRESS = False
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        utils._DEFAULT_SHOW_PROGRESS = True
+
     def test_load_subset_and_create_aggregate(self):
+        _logger.info("test gdp6h adapter, load, subset and create aggregate")
         ra = gdp6h.to_raggedarray(n_random_id=5, tmp_path=gdp6h.GDP_TMP_PATH)
         assert "rowsize" in ra.metadata
         assert "temp" in ra.data

--- a/tests/adapters/gdp6h_integ_tests.py
+++ b/tests/adapters/gdp6h_integ_tests.py
@@ -4,18 +4,10 @@ import shutil
 import numpy as np
 
 import tests.utils as testutils
-from clouddrift.adapters import gdp6h, utils
+from clouddrift.adapters import gdp6h
 
 
 class gdp6h_integration_tests(testutils.DisableProgressTestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        utils._DEFAULT_SHOW_PROGRESS = False
-
-    def tearDown(self) -> None:
-        super().tearDown()
-        utils._DEFAULT_SHOW_PROGRESS = True
-
     def test_load_subset_and_create_aggregate(self):
         ra = gdp6h.to_raggedarray(n_random_id=5, tmp_path=gdp6h.GDP_TMP_PATH)
         assert "rowsize" in ra.metadata

--- a/tests/adapters/hurdat2_integ_tests.py
+++ b/tests/adapters/hurdat2_integ_tests.py
@@ -1,15 +1,12 @@
-import logging
 import shutil
-import unittest
 
 import numpy as np
 
+import tests.utils as testutils
 from clouddrift.adapters import hurdat2, utils
 
-_logger = logging.getLogger(__name__)
 
-
-class hurdat2_integration_tests(unittest.TestCase):
+class hurdat2_integration_tests(testutils.DisableProgressTestCase):
     def setUp(self) -> None:
         super().setUp()
         utils._DEFAULT_SHOW_PROGRESS = False
@@ -19,7 +16,6 @@ class hurdat2_integration_tests(unittest.TestCase):
         utils._DEFAULT_SHOW_PROGRESS = True
 
     def test_load_create_ragged_array(self):
-        _logger.info("test hurdat2 adapter, create ragged array")
         ra = hurdat2.to_raggedarray()
         ds = ra.to_xarray()
         assert "id" in ds.coords
@@ -28,7 +24,6 @@ class hurdat2_integration_tests(unittest.TestCase):
         assert len(ds.coords["id"]) == len(ra.coords["id"])
 
     def test_conversion(self):
-        _logger.info("test hurdat2 adapter with/without conversion")
         ra = hurdat2.to_raggedarray()
         ra_non_converted = hurdat2.to_raggedarray(convert=False)
         ds = ra.to_xarray()

--- a/tests/adapters/hurdat2_integ_tests.py
+++ b/tests/adapters/hurdat2_integ_tests.py
@@ -1,13 +1,25 @@
+import logging
 import shutil
 import unittest
 
 import numpy as np
 
-from clouddrift.adapters import hurdat2
+from clouddrift.adapters import hurdat2, utils
+
+_logger = logging.getLogger(__name__)
 
 
 class hurdat2_integration_tests(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        utils._DEFAULT_SHOW_PROGRESS = False
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        utils._DEFAULT_SHOW_PROGRESS = True
+
     def test_load_create_ragged_array(self):
+        _logger.info("test hurdat2 adapter, create ragged array")
         ra = hurdat2.to_raggedarray()
         ds = ra.to_xarray()
         assert "id" in ds.coords
@@ -16,6 +28,7 @@ class hurdat2_integration_tests(unittest.TestCase):
         assert len(ds.coords["id"]) == len(ra.coords["id"])
 
     def test_conversion(self):
+        _logger.info("test hurdat2 adapter with/without conversion")
         ra = hurdat2.to_raggedarray()
         ra_non_converted = hurdat2.to_raggedarray(convert=False)
         ds = ra.to_xarray()

--- a/tests/adapters/hurdat2_integ_tests.py
+++ b/tests/adapters/hurdat2_integ_tests.py
@@ -3,18 +3,10 @@ import shutil
 import numpy as np
 
 import tests.utils as testutils
-from clouddrift.adapters import hurdat2, utils
+from clouddrift.adapters import hurdat2
 
 
 class hurdat2_integration_tests(testutils.DisableProgressTestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        utils._DEFAULT_SHOW_PROGRESS = False
-
-    def tearDown(self) -> None:
-        super().tearDown()
-        utils._DEFAULT_SHOW_PROGRESS = True
-
     def test_load_create_ragged_array(self):
         ra = hurdat2.to_raggedarray()
         ds = ra.to_xarray()

--- a/tests/datasets_tests.py
+++ b/tests/datasets_tests.py
@@ -1,46 +1,24 @@
-import logging
-import unittest
-
 import numpy as np
 
+import tests.utils as testutils
 from clouddrift import datasets
-from clouddrift.adapters import utils
 from clouddrift.ragged import apply_ragged, subset
 
-if __name__ == "__main__":
-    unittest.main()
 
-_logger = logging.getLogger(__name__)
-
-
-class datasets_tests(unittest.TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        _logger.info("Disabling show progress for all download tasks")
-        utils._DEFAULT_SHOW_PROGRESS = False
-
-    def tearDown(self) -> None:
-        super().tearDown()
-        _logger.info("Disabling show progress for all download tasks")
-        utils._DEFAULT_SHOW_PROGRESS = True
-
+class datasets_tests(testutils.DisableProgressTestCase):
     def test_gdp1h(self):
-        _logger.info("test gdp1h dataset")
         with datasets.gdp1h() as ds:
             self.assertTrue(ds)
 
     def test_gdp6h(self):
-        _logger.info("test gdp6h dataset")
         with datasets.gdp6h() as ds:
             self.assertTrue(ds)
 
     def test_glad(self):
-        _logger.info("test glad dataset")
         with datasets.glad() as ds:
             self.assertTrue(ds)
 
     def test_glad_dims_coords(self):
-        _logger.info("test glad dataset dim coords")
         with datasets.glad() as ds:
             self.assertTrue(len(ds.sizes) == 2)
             self.assertTrue("obs" in ds.dims)
@@ -50,7 +28,6 @@ class datasets_tests(unittest.TestCase):
             self.assertTrue("id" in ds.coords)
 
     def test_glad_subset_and_apply_ragged_work(self):
-        _logger.info("test glad subset and apply ragged")
         with datasets.glad() as ds:
             ds_sub = subset(
                 ds,
@@ -63,26 +40,21 @@ class datasets_tests(unittest.TestCase):
             self.assertTrue(mean_lon.size == 2)
 
     def test_spotters_opens(self):
-        _logger.info("test spotters dataset")
         with datasets.spotters() as ds:
             self.assertTrue(ds)
 
     def test_subsurface_floats_opens(self):
-        _logger.info("test subsurface floats dataset")
         with datasets.subsurface_floats() as ds:
             self.assertTrue(ds)
 
     def test_andro_opens(self):
-        _logger.info("test andro dataset")
         with datasets.andro() as ds:
             self.assertTrue(ds)
 
     def test_yomaha_opens(self):
-        _logger.info("test yomaha dataset")
         with datasets.yomaha() as ds:
             self.assertTrue(ds)
 
     def test_mosaic_opens(self):
-        _logger.info("test mosaic dataset")
         with datasets.mosaic() as ds:
             self.assertTrue(ds)

--- a/tests/datasets_tests.py
+++ b/tests/datasets_tests.py
@@ -1,28 +1,46 @@
+import logging
 import unittest
 
 import numpy as np
 
 from clouddrift import datasets
+from clouddrift.adapters import utils
 from clouddrift.ragged import apply_ragged, subset
 
 if __name__ == "__main__":
     unittest.main()
 
+_logger = logging.getLogger(__name__)
+
 
 class datasets_tests(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        _logger.info("Disabling show progress for all download tasks")
+        utils._DEFAULT_SHOW_PROGRESS = False
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        _logger.info("Disabling show progress for all download tasks")
+        utils._DEFAULT_SHOW_PROGRESS = True
+
     def test_gdp1h(self):
+        _logger.info("test gdp1h dataset")
         with datasets.gdp1h() as ds:
             self.assertTrue(ds)
 
     def test_gdp6h(self):
+        _logger.info("test gdp6h dataset")
         with datasets.gdp6h() as ds:
             self.assertTrue(ds)
 
     def test_glad(self):
+        _logger.info("test glad dataset")
         with datasets.glad() as ds:
             self.assertTrue(ds)
 
     def test_glad_dims_coords(self):
+        _logger.info("test glad dataset dim coords")
         with datasets.glad() as ds:
             self.assertTrue(len(ds.sizes) == 2)
             self.assertTrue("obs" in ds.dims)
@@ -32,6 +50,7 @@ class datasets_tests(unittest.TestCase):
             self.assertTrue("id" in ds.coords)
 
     def test_glad_subset_and_apply_ragged_work(self):
+        _logger.info("test glad subset and apply ragged")
         with datasets.glad() as ds:
             ds_sub = subset(
                 ds,
@@ -44,21 +63,26 @@ class datasets_tests(unittest.TestCase):
             self.assertTrue(mean_lon.size == 2)
 
     def test_spotters_opens(self):
+        _logger.info("test spotters dataset")
         with datasets.spotters() as ds:
             self.assertTrue(ds)
 
     def test_subsurface_floats_opens(self):
+        _logger.info("test subsurface floats dataset")
         with datasets.subsurface_floats() as ds:
             self.assertTrue(ds)
 
     def test_andro_opens(self):
+        _logger.info("test andro dataset")
         with datasets.andro() as ds:
             self.assertTrue(ds)
 
     def test_yomaha_opens(self):
+        _logger.info("test yomaha dataset")
         with datasets.yomaha() as ds:
             self.assertTrue(ds)
 
     def test_mosaic_opens(self):
+        _logger.info("test mosaic dataset")
         with datasets.mosaic() as ds:
             self.assertTrue(ds)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,16 @@
+import unittest
+
+import clouddrift.raggedarray as ragged
+from clouddrift.adapters import utils
+
+
+class DisableProgressTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        utils._DISABLE_SHOW_PROGRESS = True
+        ragged._DISABLE_SHOW_PROGRESS = True
+
+    def tearDown(self) -> None:
+        super().tearDown()
+        utils._DISABLE_SHOW_PROGRESS = False
+        ragged._DISABLE_SHOW_PROGRESS = False


### PR DESCRIPTION
I added a global var that makes it easy to configure whether any output progress is shown atleast for downloads. we will still see progress outputs for filling the ragged array. To also silence these I can do something similar but wanted to get some feedback on this approach since we should be careful with any usage/relience on global vars.