### PR TITLE
🔎 add default url and path to download function

### DIFF
--- a/clouddrift/adapters/gdp1h.py
+++ b/clouddrift/adapters/gdp1h.py
@@ -57,8 +57,8 @@ _logger = logging.getLogger(__name__)
 
 
 def download(
-    url: str,
-    tmp_path: str,
+    url: str = GDP_DATA_URL,
+    tmp_path: str = GDP_TMP_PATH,
     drifter_ids: list[int] | None = None,
     n_random_id: int | None = None,
 ):

--- a/clouddrift/adapters/gdp6h.py
+++ b/clouddrift/adapters/gdp6h.py
@@ -36,24 +36,25 @@ GDP_DATA = [
 
 
 def download(
-    url: str,
-    tmp_path: str,
-    drifter_ids: list | None = None,
+    url: str = GDP_DATA_URL,
+    tmp_path: str = GDP_TMP_PATH,
+    drifter_ids: list[int] | None = None,
     n_random_id: int | None = None,
 ):
     """Download individual NetCDF files from the AOML server.
 
     Parameters
     ----------
-    drifter_ids : list
-        List of drifter to retrieve (Default: all)
-    n_random_id : int
-        Randomly select n_random_id drifter IDs to download (Default: None)
     url : str
         URL from which to download the data (Default: GDP_DATA_URL). Alternatively, it can be GDP_DATA_URL_EXPERIMENTAL.
     tmp_path : str, optional
         Path to the directory where the individual NetCDF files are stored
         (default varies depending on operating system; /tmp/clouddrift/gdp6h on Linux)
+    drifter_ids : list
+        List of drifter to retrieve (Default: all)
+    n_random_id : int
+        Randomly select n_random_id drifter IDs to download (Default: None)
+
 
     Returns
     -------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "clouddrift"
-version = "0.35.0"
+version = "0.35.1"
 authors = [
   { name="Shane Elipot", email="selipot@miami.edu" },
   { name="Philippe Miron", email="philippemiron@gmail.com" },


### PR DESCRIPTION
This will make it easier to use the `download` functions by itself. I was trying to fix the previous Notebook examples and didn't want to have to set a URL and a PATH by default. 