### PR TITLE
🔍 reference latest DOI

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Checked with mypy](http://www.mypy-lang.org/static/mypy_badge.svg)](http://mypy-lang.org/)
 [![Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 [![NSF-2126413](https://img.shields.io/badge/NSF-2126413-blue.svg)](https://nsf.gov/awardsearch/showAward?AWD_ID=2126413)
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11081648.svg)](https://doi.org/10.5281/zenodo.11081648)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11081647.svg)](https://doi.org/10.5281/zenodo.11081647)
 [![Hits](https://hits.seeyoufarm.com/api/count/incr/badge.svg?url=https%3A%2F%2Fgithub.com%2FCloud-Drift%2Fclouddrift&count_bg=%2368C563&title_bg=%23555555&icon=&icon_color=%23E7E7E7&title=hits&edge_flat=false)](https://hits.seeyoufarm.com)
 
 ### 📦 Distributions


### PR DESCRIPTION
Instead of referencing the DOI related to a release of clouddrift we should use the latest DOI which references the latest release of clouddrift, whatever version number that may be.