### PR TITLE
🧹 Update random number generator in gdp1h and gdp6h adapters

### DIFF
--- a/clouddrift/adapters/gdp1h.py
+++ b/clouddrift/adapters/gdp1h.py
@@ -103,7 +103,7 @@ def download(
                 f"Retrieving all listed trajectories because {n_random_id} is larger than the {len(filelist)} listed trajectories."
             )
         else:
-            rng = np.random.RandomState(42)
+            rng = np.random.Generator(np.random.MT19937(42))
             filelist = sorted(rng.choice(filelist, n_random_id, replace=False))
 
     download_with_progress(

--- a/clouddrift/adapters/gdp6h.py
+++ b/clouddrift/adapters/gdp6h.py
@@ -94,7 +94,7 @@ def download(
                 f"Retrieving all listed trajectories because {n_random_id} is larger than the {len(drifter_urls)} listed trajectories."
             )
         else:
-            rng = np.random.RandomState(42)
+            rng = np.random.Generator(np.random.MT19937(42))
             drifter_urls = list(rng.choice(drifter_urls, n_random_id, replace=False))
 
     download_with_progress(


### PR DESCRIPTION
The code changes update the random number generator in the `gdp1h.py` and `gdp6h.py` adapters. The previous usage of `np.random.RandomState` has been replaced with `np.random.Generator(np.random.MT19937)`. This change ensures consistent and reproducible random number generation.