### PR TITLE
🧹 Update type comparison in ragged.py

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,7 @@ Common emojis to use are as follow:
 ❗ Deprecation of a feature
 ⛔ Removal of feature
 🐛 Bugfix
+🧹 Chore / refactoring / migration / dependency deprecation related
 ⚡ Performance/memory improvements
 🔍 Documentation, refactoring
 🔧 Tooling/Build scripts/CI (other non-application changes)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,7 +63,7 @@ Common emojis to use are as follow:
 🐛 Bugfix
 🧹 Chore / refactoring / migration / dependency deprecation related
 ⚡ Performance/memory improvements
-🔍 Documentation, refactoring
+🔍 Documentation
 🔧 Tooling/Build scripts/CI (other non-application changes)
 ```
 

--- a/clouddrift/ragged.py
+++ b/clouddrift/ragged.py
@@ -523,7 +523,7 @@ def segment(
     if type(tolerance) in [np.timedelta64, timedelta]:
         tolerance = pd.Timedelta(tolerance)
 
-    if type(tolerance) == pd.Timedelta:
+    if isinstance(tolerance, pd.Timedelta):
         positive_tol = tolerance >= pd.Timedelta("0 seconds")
     else:
         positive_tol = tolerance >= 0


### PR DESCRIPTION
The code changes in ragged.py update the type comparison for the `tolerance` variable. Instead of using the `type()` function, it now uses the `isinstance()` function to check if `tolerance` is an instance of `pd.Timedelta`. This change improves the accuracy and reliability of the comparison.

Note: This commit message follows the established convention of using the "chore" type for non-functional changes that don't affect the code's behavior.