### PR TITLE
⭐️ new functions `index_to_row` and `rowsize_to_rowvector`

### DIFF
--- a/clouddrift/ragged.py
+++ b/clouddrift/ragged.py
@@ -855,14 +855,14 @@ def unpack(
 
 
 def index_to_row(
-    index: int | list[int],
+    index: int | list[int] | np.ndarray,
     rowsize: list[int] | np.ndarray | xr.DataArray,
 ) -> list:
     """Obtain a list of row indices from a list of observation indices of a ragged array.
 
     Parameters
     ----------
-    index : int or list
+    index : int or list or np.ndarray
         A integer observation index or a list of observation indices of a ragged array.
     rowsize : list or np.ndarray or xr.DataArray
         A sequence of row sizes of a ragged array.
@@ -900,7 +900,7 @@ def index_to_row(
     rowsize_index = rowsize_to_index(rowsize)
 
     # test that no index is out of bounds
-    if any((i < rowsize_index[0]) | (i >= rowsize_index[-1]) for i in index_list):
+    if any([(i < rowsize_index[0]) | (i >= rowsize_index[-1]) for i in index_list]):
         raise ValueError("Input index out of bounds based on input rowsize")
 
     return (np.searchsorted(rowsize_index, index_list, side="right") - 1).tolist()

--- a/clouddrift/ragged.py
+++ b/clouddrift/ragged.py
@@ -911,27 +911,33 @@ def index_to_row(
     To obtain the row index of observation 5 within a ragged array of three consecutive
     rows of sizes 2, 4, and 3:
     >>> index_to_row(5, [2, 4, 3])
-    1
+    [1]
 
     To obtain the row indices of observations 0, 2, and 4 within a ragged array of three consecutive
     rows of sizes 2, 4, and 3:
     >>> index_to_row([0, 2, 4], [2, 4, 3])
-    [0, 1, 2]
+    [0, 1, 1]
 
     """
     # if index is an integer, convert it to a list
-    if isinstance(index, int):
+    if isinstance(index, int) | isinstance(index, float):
         index_list = [index]
     else:
         index_list = index
 
-    # if index is not a list of integers, raise an error
-    if not all(isinstance(i, int) for i in index_list):
+    # if index is not a list of integers or integer-likes, raise an error
+    if not all(
+        isinstance(i, int) or (isinstance(i, float) and i % 1 == 0) for i in index_list
+    ):
         raise ValueError("The index must be an integer or a list of integers.")
 
-    rowvector_flattened = rowsize_to_rowvector(rowsize)
+    rowsize_index = rowsize_to_index(rowsize)
 
-    return [rowvector_flattened[i] for i in index_list]
+    # test that no index is out of bounds
+    if any((i < rowsize_index[0]) | (i >= rowsize_index[-1]) for i in index_list):
+        raise ValueError("Input index out of bounds based on input rowsize")
+
+    return (np.searchsorted(rowsize_index, index_list, side="right") - 1).tolist()
 
 
 def _mask_var(

--- a/clouddrift/ragged.py
+++ b/clouddrift/ragged.py
@@ -854,40 +854,6 @@ def unpack(
     return [unpacked[i] for i in rows]
 
 
-def rowsize_to_rowvector(
-    rowsize: list[int] | np.ndarray | xr.DataArray,
-) -> list:
-    """Obtain a list of repeated row indices from a list of row sizes of a ragged array.
-
-    Parameters
-    ----------
-    rowsize : list or np.ndarray or xr.DataArray
-        A sequence of row sizes greater than zero.
-
-    Returns
-    -------
-    list
-        A list of repeated row indices.
-
-    Examples
-    --------
-    To obtain the repeated row indices within a ragged array of three consecutive rows of sizes 2, 4, and 3:
-    >>> rowsize_to_rowvector([2, 4, 3])
-    [0, 0, 1, 1, 1, 1, 2, 2, 2]
-    """
-    # test is there is any zero or negative rowsizes
-    if any(i <= 0 for i in rowsize):
-        raise ValueError("The row sizes must be greater than zero.")
-
-    if isinstance(rowsize, xr.DataArray):
-        rowsize = rowsize.values
-
-    rowvector = [[i] * rowsize[i] for i in range(len(rowsize))]
-    rowvector_flattened = [item for sublist in rowvector for item in sublist]
-
-    return rowvector_flattened
-
-
 def index_to_row(
     index: int | list[int],
     rowsize: list[int] | np.ndarray | xr.DataArray,

--- a/clouddrift/ragged.py
+++ b/clouddrift/ragged.py
@@ -885,15 +885,19 @@ def index_to_row(
     [0, 1, 1]
 
     """
-    # if index is an integer, convert it to a list
-    if isinstance(index, int) | isinstance(index, float):
+    # convert index to list if it is not
+    if isinstance(index, xr.DataArray):
+        index_list = [int(i) for i in index.values]
+    elif isinstance(index, np.ndarray):
+        index_list = [int(i) for i in index]
+    elif isinstance(index, int):
         index_list = [index]
     else:
         index_list = index
 
     # if index is not a list of integers or integer-likes, raise an error
     if not all(
-        isinstance(i, int) or (isinstance(i, float) and i % 1 == 0) for i in index_list
+        isinstance(i, int) for i in index_list
     ):
         raise ValueError("The index must be an integer or a list of integers.")
 

--- a/clouddrift/ragged.py
+++ b/clouddrift/ragged.py
@@ -854,7 +854,7 @@ def unpack(
     return [unpacked[i] for i in rows]
 
 
-def index_to_row(
+def obs_index_to_row(
     index: int | list[int] | np.ndarray,
     rowsize: list[int] | np.ndarray | xr.DataArray,
 ) -> list:
@@ -876,12 +876,12 @@ def index_to_row(
     --------
     To obtain the row index of observation 5 within a ragged array of three consecutive
     rows of sizes 2, 4, and 3:
-    >>> index_to_row(5, [2, 4, 3])
+    >>> obs_index_to_row(5, [2, 4, 3])
     [1]
 
     To obtain the row indices of observations 0, 2, and 4 within a ragged array of three consecutive
     rows of sizes 2, 4, and 3:
-    >>> index_to_row([0, 2, 4], [2, 4, 3])
+    >>> obs_index_to_row([0, 2, 4], [2, 4, 3])
     [0, 1, 1]
 
     """

--- a/clouddrift/ragged.py
+++ b/clouddrift/ragged.py
@@ -855,7 +855,7 @@ def unpack(
 
 
 def obs_index_to_row(
-    index: int | list[int] | np.ndarray,
+    index: int | list[int] | np.ndarray | xr.DataArray,
     rowsize: list[int] | np.ndarray | xr.DataArray,
 ) -> list:
     """Obtain a list of row indices from a list of observation indices of a ragged array.

--- a/clouddrift/ragged.py
+++ b/clouddrift/ragged.py
@@ -854,6 +854,86 @@ def unpack(
     return [unpacked[i] for i in rows]
 
 
+def rowsize_to_rowvector(
+    rowsize: list[int] | np.ndarray | xr.DataArray,
+) -> list:
+    """Obtain a list of repeated row indices from a list of row sizes of a ragged array.
+
+    Parameters
+    ----------
+    rowsize : list or np.ndarray or xr.DataArray
+        A sequence of row sizes greater than zero.
+
+    Returns
+    -------
+    list
+        A list of repeated row indices.
+
+    Examples
+    --------
+    To obtain the repeated row indices within a ragged array of three consecutive rows of sizes 2, 4, and 3:
+    >>> rowsize_to_rowvector([2, 4, 3])
+    [0, 0, 1, 1, 1, 1, 2, 2, 2]
+    """
+    # test is there is any zero or negative rowsizes
+    if any(i <= 0 for i in rowsize):
+        raise ValueError("The row sizes must be greater than zero.")
+
+    if isinstance(rowsize, xr.DataArray):
+        rowsize = rowsize.values
+
+    rowvector = [[i] * rowsize[i] for i in range(len(rowsize))]
+    rowvector_flattened = [item for sublist in rowvector for item in sublist]
+
+    return rowvector_flattened
+
+
+def index_to_row(
+    index: int | list[int],
+    rowsize: list[int] | np.ndarray | xr.DataArray,
+) -> list:
+    """Obtain a list of row indices from a list of observation indices of a ragged array.
+
+    Parameters
+    ----------
+    index : int or list
+        A integer observation index or a list of observation indices of a ragged array.
+    rowsize : list or np.ndarray or xr.DataArray
+        A sequence of row sizes of a ragged array.
+
+    Returns
+    -------
+    list
+        A list of row indices.
+
+    Examples
+    --------
+    To obtain the row index of observation 5 within a ragged array of three consecutive
+    rows of sizes 2, 4, and 3:
+    >>> index_to_row(5, [2, 4, 3])
+    1
+
+    To obtain the row indices of observations 0, 2, and 4 within a ragged array of three consecutive
+    rows of sizes 2, 4, and 3:
+    >>> index_to_row([0, 2, 4], [2, 4, 3])
+    [0, 1, 2]
+
+    """
+    # if index is an integer, convert it to a list
+    if isinstance(index, int):
+        index_list = [index]
+    else:
+        index_list = index
+
+    # if index is not a list of integers, raise an error
+    if not all(isinstance(i, int) for i in index_list):
+        raise ValueError("The index must be an integer or a list of integers.")
+
+    rowvector_flattened = rowsize_to_rowvector(rowsize)
+
+    return [rowvector_flattened[i] for i in index_list]
+
+
 def _mask_var(
     var: xr.DataArray | list[xr.DataArray],
     criterion: tuple | list | np.ndarray | xr.DataArray | bool | float | int | Callable,

--- a/clouddrift/ragged.py
+++ b/clouddrift/ragged.py
@@ -896,9 +896,7 @@ def obs_index_to_row(
         index_list = index
 
     # if index is not a list of integers or integer-likes, raise an error
-    if not all(
-        isinstance(i, int) for i in index_list
-    ):
+    if not all(isinstance(i, int) for i in index_list):
         raise ValueError("The index must be an integer or a list of integers.")
 
     rowsize_index = rowsize_to_index(rowsize)

--- a/tests/ragged_tests.py
+++ b/tests/ragged_tests.py
@@ -811,37 +811,6 @@ class unpack_tests(unittest.TestCase):
         )
 
 
-class rowsize_to_rowvector_tests(unittest.TestCase):
-    def test_rowsize_to_rowvector(self):
-        rowsize = [2, 3, 4]
-        rowvector = rowsize_to_rowvector(rowsize)
-        self.assertTrue(np.all(rowvector == np.array([0, 0, 1, 1, 1, 2, 2, 2, 2])))
-
-    def test_rowsize_to_rowvector_empty(self):
-        rowsize = []
-        rowvector = rowsize_to_rowvector(rowsize)
-        self.assertTrue(rowvector == [])
-
-    def test_rowsize_to_rowvector_zero(self):
-        rowsize = [2, 3, 0, 4]
-        with self.assertRaises(ValueError):
-            rowsize_to_rowvector(rowsize)
-
-    def test_rowsize_to_rowvector_negative(self):
-        rowsize = [2, 3, -1, 4]
-        with self.assertRaises(ValueError):
-            rowsize_to_rowvector(rowsize)
-
-    def test_rowsize_to_rowvector_array_like(self):
-        rowsize = np.array([2, 3, 4])
-        rowvector = rowsize_to_rowvector(rowsize)
-        self.assertTrue(np.all(rowvector == np.array([0, 0, 1, 1, 1, 2, 2, 2, 2])))
-
-        rowsize = xr.DataArray(data=[2, 3, 4])
-        rowvector = rowsize_to_rowvector(rowsize)
-        self.assertTrue(np.all(rowvector == np.array([0, 0, 1, 1, 1, 2, 2, 2, 2])))
-
-
 class index_to_row_tests(unittest.TestCase):
     def test_index_to_row(self):
         rowsize = [2, 5, 3]

--- a/tests/ragged_tests.py
+++ b/tests/ragged_tests.py
@@ -11,7 +11,7 @@ from clouddrift.kinematics import velocity_from_position
 from clouddrift.ragged import (
     apply_ragged,
     chunk,
-    index_to_row,
+    obs_index_to_row,
     prune,
     ragged_to_regular,
     regular_to_ragged,
@@ -810,63 +810,57 @@ class unpack_tests(unittest.TestCase):
         )
 
 
-class index_to_row_tests(unittest.TestCase):
-    def test_index_to_row(self):
+class obs_index_to_row_tests(unittest.TestCase):
+    def test_obs_index_to_row(self):
         index = list(range(10))
         rowsize = [2, 5, 3]
-        row = index_to_row(index, rowsize)
+        row = obs_index_to_row(index, rowsize)
         self.assertTrue(np.all(row == [0, 0, 1, 1, 1, 1, 1, 2, 2, 2]))
 
-    def test_index_to_row_array_like_rowsize(self):
+    def test_obs_index_to_row_array_like_rowsize(self):
         index = list(range(10))
         rowsize = xr.DataArray(data=[2, 5, 3])
-        row = index_to_row(index, rowsize)
+        row = obs_index_to_row(index, rowsize)
         self.assertTrue(np.all(row == np.array([0, 0, 1, 1, 1, 1, 1, 2, 2, 2])))
 
-    def test_index_to_row_array_rowsize(self):
+    def test_obs_index_to_row_array_rowsize(self):
         index = list(range(10))
         rowsize = np.array([2, 5, 3])
-        row = index_to_row(index, rowsize)
+        row = obs_index_to_row(index, rowsize)
         self.assertTrue(np.all(row == np.array([0, 0, 1, 1, 1, 1, 1, 2, 2, 2])))
 
-    def test_index_to_row_array_like_index(self):
+    def test_obs_index_to_row_array_like_index(self):
         index = xr.DataArray(data=list(range(10)))
         rowsize = [2, 5, 3]
-        row = index_to_row(index, rowsize)
+        row = obs_index_to_row(index, rowsize)
         self.assertTrue(np.all(row == np.array([0, 0, 1, 1, 1, 1, 1, 2, 2, 2])))
 
-    def test_index_to_row_array_index(self):
+    def test_obs_index_to_row_array_index(self):
         index = np.array(range(10))
         rowsize = [2, 5, 3]
-        row = index_to_row(index, rowsize)
+        row = obs_index_to_row(index, rowsize)
         self.assertTrue(np.all(row == np.array([0, 0, 1, 1, 1, 1, 1, 2, 2, 2])))
 
-    def test_index_to_row_array_like(self):
+    def test_obs_index_to_row_array_like(self):
         index = xr.DataArray(data=list(range(10)))
         rowsize = xr.DataArray(data=[2, 5, 3])
-        row = index_to_row(index, rowsize)
+        row = obs_index_to_row(index, rowsize)
         self.assertTrue(np.all(row == np.array([0, 0, 1, 1, 1, 1, 1, 2, 2, 2])))
 
-    def test_index_to_row_array(self):
+    def test_obs_index_to_row_array(self):
         index = np.array(range(10))
         rowsize = np.array([2, 5, 3])
-        row = index_to_row(index, rowsize)
+        row = obs_index_to_row(index, rowsize)
         self.assertTrue(np.all(row == np.array([0, 0, 1, 1, 1, 1, 1, 2, 2, 2])))
 
-   # def test_index_to_row_integer(self):
-    #     rowsize = [2, 5, 3]
-    #     index = 1.2
-    #     with self.assertRaises(ValueError):
-    #         index_to_row(index, rowsize)
-
-    def test_index_to_row_out_of_bounds(self):
+    def test_obs_index_to_row_out_of_bounds(self):
         index = 10
         rowsize = [2, 5, 3]
         with self.assertRaises(ValueError):
-            index_to_row(index, rowsize)
+            obs_index_to_row(index, rowsize)
 
-    def test_index_to_row_negative(self):
+    def test_obs_index_to_row_negative(self):
         index = -1
         rowsize = [2, 5, 3]
         with self.assertRaises(ValueError):
-            index_to_row(index, rowsize)
+            obs_index_to_row(index, rowsize)

--- a/tests/ragged_tests.py
+++ b/tests/ragged_tests.py
@@ -812,31 +812,61 @@ class unpack_tests(unittest.TestCase):
 
 class index_to_row_tests(unittest.TestCase):
     def test_index_to_row(self):
-        rowsize = [2, 5, 3]
         index = list(range(10))
+        rowsize = [2, 5, 3]
         row = index_to_row(index, rowsize)
         self.assertTrue(np.all(row == [0, 0, 1, 1, 1, 1, 1, 2, 2, 2]))
 
-    def test_index_to_row_array_like(self):
-        rowsize = xr.DataArray(data=[2, 5, 3])
+    def test_index_to_row_array_like_rowsize(self):
         index = list(range(10))
+        rowsize = xr.DataArray(data=[2, 5, 3])
         row = index_to_row(index, rowsize)
         self.assertTrue(np.all(row == np.array([0, 0, 1, 1, 1, 1, 1, 2, 2, 2])))
 
-    def test_index_to_row_integer(self):
+    def test_index_to_row_array_rowsize(self):
+        index = list(range(10))
+        rowsize = np.array([2, 5, 3])
+        row = index_to_row(index, rowsize)
+        self.assertTrue(np.all(row == np.array([0, 0, 1, 1, 1, 1, 1, 2, 2, 2])))
+
+    def test_index_to_row_array_like_index(self):
+        index = xr.DataArray(data=list(range(10)))
         rowsize = [2, 5, 3]
-        index = 1.2
-        with self.assertRaises(ValueError):
-            index_to_row(index, rowsize)
+        row = index_to_row(index, rowsize)
+        self.assertTrue(np.all(row == np.array([0, 0, 1, 1, 1, 1, 1, 2, 2, 2])))
+
+    def test_index_to_row_array_index(self):
+        index = np.array(range(10))
+        rowsize = [2, 5, 3]
+        row = index_to_row(index, rowsize)
+        self.assertTrue(np.all(row == np.array([0, 0, 1, 1, 1, 1, 1, 2, 2, 2])))
+
+    def test_index_to_row_array_like(self):
+        index = xr.DataArray(data=list(range(10)))
+        rowsize = xr.DataArray(data=[2, 5, 3])
+        row = index_to_row(index, rowsize)
+        self.assertTrue(np.all(row == np.array([0, 0, 1, 1, 1, 1, 1, 2, 2, 2])))
+
+    def test_index_to_row_array(self):
+        index = np.array(range(10))
+        rowsize = np.array([2, 5, 3])
+        row = index_to_row(index, rowsize)
+        self.assertTrue(np.all(row == np.array([0, 0, 1, 1, 1, 1, 1, 2, 2, 2])))
+
+   # def test_index_to_row_integer(self):
+    #     rowsize = [2, 5, 3]
+    #     index = 1.2
+    #     with self.assertRaises(ValueError):
+    #         index_to_row(index, rowsize)
 
     def test_index_to_row_out_of_bounds(self):
-        rowsize = [2, 5, 3]
         index = 10
+        rowsize = [2, 5, 3]
         with self.assertRaises(ValueError):
             index_to_row(index, rowsize)
 
     def test_index_to_row_negative(self):
-        rowsize = [2, 5, 3]
         index = -1
+        rowsize = [2, 5, 3]
         with self.assertRaises(ValueError):
             index_to_row(index, rowsize)

--- a/tests/ragged_tests.py
+++ b/tests/ragged_tests.py
@@ -11,14 +11,14 @@ from clouddrift.kinematics import velocity_from_position
 from clouddrift.ragged import (
     apply_ragged,
     chunk,
+    index_to_row,
     prune,
     ragged_to_regular,
     regular_to_ragged,
+    rowsize_to_rowvector,
     segment,
     subset,
     unpack,
-    rowsize_to_rowvector,
-    index_to_row,
 )
 from clouddrift.raggedarray import RaggedArray
 

--- a/tests/ragged_tests.py
+++ b/tests/ragged_tests.py
@@ -854,3 +854,21 @@ class index_to_row_tests(unittest.TestCase):
         index = list(range(10))
         row = index_to_row(index, rowsize)
         self.assertTrue(np.all(row == np.array([0, 0, 1, 1, 1, 1, 1, 2, 2, 2])))
+
+    def test_index_to_row_integer(self):
+        rowsize = [2, 5, 3]
+        index = 1.2
+        with self.assertRaises(ValueError):
+            index_to_row(index, rowsize)
+
+    def test_index_to_row_out_of_bounds(self):
+        rowsize = [2, 5, 3]
+        index = 10
+        with self.assertRaises(ValueError):
+            index_to_row(index, rowsize)
+
+    def test_index_to_row_negative(self):
+        rowsize = [2, 5, 3]
+        index = -1
+        with self.assertRaises(ValueError):
+            index_to_row(index, rowsize)

--- a/tests/ragged_tests.py
+++ b/tests/ragged_tests.py
@@ -825,12 +825,12 @@ class rowsize_to_rowvector_tests(unittest.TestCase):
     def test_rowsize_to_rowvector_zero(self):
         rowsize = [2, 3, 0, 4]
         with self.assertRaises(ValueError):
-            rowvector = rowsize_to_rowvector(rowsize)
+            rowsize_to_rowvector(rowsize)
 
     def test_rowsize_to_rowvector_negative(self):
         rowsize = [2, 3, -1, 4]
         with self.assertRaises(ValueError):
-            rowvector = rowsize_to_rowvector(rowsize)
+            rowsize_to_rowvector(rowsize)
 
     def test_rowsize_to_rowvector_array_like(self):
         rowsize = np.array([2, 3, 4])

--- a/tests/ragged_tests.py
+++ b/tests/ragged_tests.py
@@ -15,7 +15,6 @@ from clouddrift.ragged import (
     prune,
     ragged_to_regular,
     regular_to_ragged,
-    rowsize_to_rowvector,
     segment,
     subset,
     unpack,


### PR DESCRIPTION
New functions `index_to_row` and `rowsize_to_rowvector` to easily find the rows of observations. This fixes #501.

I think these are useful if one tries to find the row of a given observation. As an example, let's say you notice a weird observation and you want to identify the trajectory (or row) associated with that observation. 

I am open to name changes and algorithm changes. Please suggest!