### PR TITLE
🧹 Update dataset URL to version 2.01.1

### DIFF
--- a/clouddrift/datasets.py
+++ b/clouddrift/datasets.py
@@ -78,9 +78,8 @@ def gdp1h(decode_times: bool = True) -> xr.Dataset:
     --------
     :func:`gdp6h`
     """
-    url = "https://noaa-oar-hourly-gdp-pds.s3.amazonaws.com/latest/gdp-v2.01.zarr"
+    url = "https://noaa-oar-hourly-gdp-pds.s3.amazonaws.com/latest/gdp-v2.01.1.zarr"
     ds = xr.open_dataset(url, engine="zarr", decode_times=decode_times)
-    ds = ds.rename_vars({"ID": "id"}).assign_coords({"id": ds.ID}).drop_vars(["ids"])
     return ds
 
 


### PR DESCRIPTION
The code changes update the dataset URL in the `gdp1h` function to version 2.01.1. This ensures that the latest version of the dataset is being used. The previous URL was "https://noaa-oar-hourly-gdp-pds.s3.amazonaws.com/latest/gdp-v2.01.zarr" and it has been updated to "https://noaa-oar-hourly-gdp-pds.s3.amazonaws.com/latest/gdp-v2.01.1.zarr".

Co-authored-by: Shane Elipot <selipot@miami.edu>
Co-authored-by: Philippe Miron <philippemiron@gmail.com>