### PR TITLE
🧹 fix wrong None arguments

### DIFF
--- a/clouddrift/kinematics.py
+++ b/clouddrift/kinematics.py
@@ -65,8 +65,8 @@ def inertial_oscillation_from_position(
     latitude: np.ndarray,
     relative_bandwidth: float | None = None,
     wavelet_duration: float | None = None,
-    time_step: float | None = 3600.0,
-    relative_vorticity: float | np.ndarray | None = 0.0,
+    time_step: float = 3600.0,
+    relative_vorticity: float | np.ndarray = 0.0,
 ) -> np.ndarray:
     """Extract inertial oscillations from consecutive geographical positions.
 
@@ -324,9 +324,9 @@ def position_from_velocity(
     time: np.ndarray,
     x_origin: float,
     y_origin: float,
-    coord_system: str | None = "spherical",
-    integration_scheme: str | None = "forward",
-    time_axis: int | None = -1,
+    coord_system: str = "spherical",
+    integration_scheme: str = "forward",
+    time_axis: int = -1,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Compute positions from arrays of velocities and time and a pair of origin
     coordinates.
@@ -528,9 +528,9 @@ def velocity_from_position(
     x: np.ndarray,
     y: np.ndarray,
     time: np.ndarray,
-    coord_system: str | None = "spherical",
-    difference_scheme: str | None = "forward",
-    time_axis: int | None = -1,
+    coord_system: str = "spherical",
+    difference_scheme: str = "forward",
+    time_axis: int = -1,
 ) -> tuple[xr.DataArray, xr.DataArray]:
     """Compute velocity from arrays of positions and time.
 
@@ -786,8 +786,8 @@ def spin(
     u: np.ndarray,
     v: np.ndarray,
     time: np.ndarray,
-    difference_scheme: str | None = "forward",
-    time_axis: int | None = -1,
+    difference_scheme: str = "forward",
+    time_axis: int = -1,
 ) -> float | np.ndarray:
     """Compute spin continuously from velocities and times.
 

--- a/clouddrift/pairs.py
+++ b/clouddrift/pairs.py
@@ -22,8 +22,8 @@ def chance_pair(
     lat2: array_like,
     time1: array_like | None = None,
     time2: array_like | None = None,
-    space_distance: float | None = 0,
-    time_distance: float | None = 0,
+    space_distance: float = 0,
+    time_distance: float = 0,
 ):
     """Given two sets of longitudes, latitudes, and times arrays, return in pairs
     the indices of collocated data points that are within prescribed distances
@@ -165,9 +165,9 @@ def chance_pairs_from_ragged(
     lon: array_like,
     lat: array_like,
     rowsize: array_like,
-    space_distance: float | None = 0,
+    space_distance: float = 0,
     time: array_like | None = None,
-    time_distance: float | None = 0,
+    time_distance: float = 0,
 ) -> list[tuple[tuple[int, int], tuple[np.ndarray, np.ndarray]]]:
     """Return all chance pairs of contiguous trajectories in a ragged array,
     and their collocated points in space and (optionally) time, given input
@@ -300,7 +300,7 @@ def pair_bounding_box_overlap(
     lat1: array_like,
     lon2: array_like,
     lat2: array_like,
-    distance: float | None = 0,
+    distance: float = 0,
 ) -> tuple[np.ndarray[bool], np.ndarray[bool]]:
     """Given two arrays of longitudes and latitudes, return boolean masks for
     their overlapping bounding boxes.
@@ -477,7 +477,7 @@ def pair_time_distance(
 def pair_time_overlap(
     time1: array_like,
     time2: array_like,
-    distance: float | None = 0,
+    distance: float = 0,
 ) -> tuple[np.ndarray[int], np.ndarray[int]]:
     """Given two arrays of times (or any other monotonically increasing
     quantity), return indices where the times are within a prescribed distance.

--- a/clouddrift/plotting.py
+++ b/clouddrift/plotting.py
@@ -16,7 +16,7 @@ def plot_ragged(
     rowsize: list | np.ndarray | pd.Series | xr.DataArray,
     *args,
     colors: list | np.ndarray | pd.Series | xr.DataArray | None = None,
-    tolerance: float | int | None = 180,
+    tolerance: float | int = 180,
     **kwargs,
 ):
     """Plot individually the rows of a ragged array dataset on a Matplotlib Axes

--- a/clouddrift/raggedarray.py
+++ b/clouddrift/raggedarray.py
@@ -27,8 +27,8 @@ class RaggedArray:
         coords: dict,
         metadata: dict,
         data: dict,
-        attrs_global: dict | None = {},
-        attrs_variables: dict | None = {},
+        attrs_global: dict = {},
+        attrs_variables: dict = {},
         name_dims: dict[str, DimNames] = {},
         coord_dims: dict[str, str] = {},
     ):

--- a/clouddrift/signal.py
+++ b/clouddrift/signal.py
@@ -8,8 +8,8 @@ import xarray as xr
 
 def analytic_signal(
     x: np.ndarray | xr.DataArray,
-    boundary: str | None = "mirror",
-    time_axis: int | None = -1,
+    boundary: str = "mirror",
+    time_axis: int = -1,
 ) -> np.ndarray | tuple[np.ndarray, np.ndarray]:
     """Return the analytic signal from a real-valued signal or the analytic and
     conjugate analytic signals from a complex-valued signal.
@@ -160,7 +160,7 @@ def analytic_signal(
 def cartesian_to_rotary(
     ua: np.ndarray | xr.DataArray,
     va: np.ndarray | xr.DataArray,
-    time_axis: int | None = -1,
+    time_axis: int = -1,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Return rotary signals (wp,wn) from analytic Cartesian signals (ua,va).
 
@@ -396,7 +396,7 @@ def modulated_ellipse_signal(
 def rotary_to_cartesian(
     wp: np.ndarray | xr.DataArray,
     wn: np.ndarray | xr.DataArray,
-    time_axis: int | None = -1,
+    time_axis: int = -1,
 ) -> tuple[np.ndarray, np.ndarray]:
     """Return Cartesian analytic signals (ua, va) from rotary signals (wp, wn)
     as ua = wp + wn and va = -1j * (wp - wn).

--- a/clouddrift/sphere.py
+++ b/clouddrift/sphere.py
@@ -254,7 +254,7 @@ def position_from_distance_and_bearing(
     lat_rad = np.deg2rad(lat)
     lon_rad = np.deg2rad(lon)
 
-    distance_rad = distance / EARTH_RADIUS_METERS
+    distance_rad = np.asarray(distance) / EARTH_RADIUS_METERS
 
     lat2_rad = np.arcsin(
         np.sin(lat_rad) * np.cos(distance_rad)
@@ -268,7 +268,7 @@ def position_from_distance_and_bearing(
     return np.rad2deg(lon2_rad), np.rad2deg(lat2_rad)
 
 
-def recast_lon(lon: np.ndarray, lon0: float | None = -180) -> np.ndarray:
+def recast_lon(lon: np.ndarray, lon0: float = -180) -> np.ndarray:
     """Recast (convert) longitude values to a selected range of 360 degrees
     starting from ``lon0``.
 
@@ -529,7 +529,7 @@ def sphere_to_plane(
 def spherical_to_cartesian(
     lon: float | list | np.ndarray | xr.DataArray,
     lat: float | list | np.ndarray | xr.DataArray,
-    radius: float | None = EARTH_RADIUS_METERS,
+    radius: float = EARTH_RADIUS_METERS,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Converts latitude and longitude on a spherical body to
      three-dimensional Cartesian coordinates.
@@ -666,7 +666,7 @@ def cartesian_to_tangentplane(
     w: float | np.ndarray,
     longitude: float | np.ndarray,
     latitude: float | np.ndarray,
-) -> tuple[float] | tuple[np.ndarray]:
+) -> tuple[float, float] | tuple[np.ndarray, np.ndarray]:
     """
     Project a three-dimensional Cartesian vector on a plane tangent to
     a spherical Earth.
@@ -730,7 +730,7 @@ def tangentplane_to_cartesian(
     vp: float | np.ndarray,
     longitude: float | np.ndarray,
     latitude: float | np.ndarray,
-) -> tuple[float] | tuple[np.ndarray]:
+) -> tuple[float, float, float] | tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     Return the three-dimensional Cartesian components of a vector contained in
     a plane tangent to a spherical Earth.

--- a/clouddrift/wavelet.py
+++ b/clouddrift/wavelet.py
@@ -25,12 +25,12 @@ def morse_wavelet_transform(
     gamma: float,
     beta: float,
     radian_frequency: np.ndarray,
-    complex: bool | None = False,
-    order: int | None = 1,
-    normalization: str | None = "bandpass",
-    boundary: str | None = "mirror",
-    time_axis: int | None = -1,
-) -> tuple[np.ndarray] | np.ndarray:
+    complex: bool = False,
+    order: int = 1,
+    normalization: str = "bandpass",
+    boundary: str = "mirror",
+    time_axis: int = -1,
+) -> tuple[np.ndarray, np.ndarray] | np.ndarray:
     """
     Apply a continuous wavelet transform to an input signal using the generalized Morse
     wavelets of Olhede and Walden (2002). The wavelet transform is normalized differently
@@ -202,10 +202,10 @@ def morse_wavelet_transform(
 def wavelet_transform(
     x: np.ndarray,
     wavelet: np.ndarray,
-    boundary: str | None = "mirror",
-    time_axis: int | None = -1,
-    freq_axis: int | None = -2,
-    order_axis: int | None = -3,
+    boundary: str = "mirror",
+    time_axis: int = -1,
+    freq_axis: int = -2,
+    order_axis: int = -3,
 ) -> np.ndarray:
     """
     Apply a continuous wavelet transform to an input signal using an input wavelet
@@ -347,8 +347,8 @@ def morse_wavelet(
     gamma: float,
     beta: float,
     radian_frequency: np.ndarray,
-    order: int | None = 1,
-    normalization: str | None = "bandpass",
+    order: int = 1,
+    normalization: str = "bandpass",
 ) -> tuple[np.ndarray, np.ndarray]:
     """
     Compute the generalized Morse wavelets of Olhede and Walden (2002), doi: 10.1109/TSP.2002.804066.
@@ -492,8 +492,8 @@ def _morse_wavelet_first_family(
     beta: float,
     norm_radian_frequency: np.ndarray,
     wavezero: np.ndarray,
-    order: int | None = 1,
-    normalization: str | None = "bandpass",
+    order: int = 1,
+    normalization: str = "bandpass",
 ) -> np.ndarray:
     """
     Derive first family of Morse wavelets. Internal use only.
@@ -525,7 +525,7 @@ def _morse_wavelet_first_family(
 def morse_freq(
     gamma: np.ndarray | float,
     beta: np.ndarray | float,
-) -> tuple[np.ndarray] | tuple[float]:
+) -> tuple[np.ndarray, np.ndarray, np.ndarray] | tuple[float, float, float]:
     """
     Frequency measures for generalized Morse wavelets. This functions calculates
     three different measures fm, fe, and fi of the frequency of the lowest-order generalized Morse
@@ -605,9 +605,9 @@ def morse_logspace_freq(
     gamma: float,
     beta: float,
     length: int,
-    highset: tuple[float] | None = (0.1, np.pi),
-    lowset: tuple[float] | None = (5, 0),
-    density: int | None = 4,
+    highset: tuple[float, float] = (0.1, np.pi),
+    lowset: tuple[float, float] = (5, 0),
+    density: int = 4,
 ) -> np.ndarray:
     """
     Compute logarithmically-spaced frequencies for generalized Morse wavelets
@@ -715,7 +715,7 @@ def _morsehigh(
 def morse_properties(
     gamma: np.ndarray | float,
     beta: np.ndarray | float,
-) -> tuple[np.ndarray] | tuple[float]:
+) -> tuple[np.ndarray, np.ndarray, np.ndarray] | tuple[float, float, float]:
     """
     Calculate the properties of the demodulated generalized Morse wavelets.
     See Lilly and Olhede (2009), doi: 10.1109/TSP.2008.2007607.
@@ -757,8 +757,8 @@ def morse_properties(
 def morse_amplitude(
     gamma: np.ndarray | float,
     beta: np.ndarray | float,
-    order: np.int64 | None = 1,
-    normalization: str | None = "bandpass",
+    order: int = 1,
+    normalization: str = "bandpass",
 ) -> float:
     """
     Calculate the amplitude coefficient of the generalized Morse wavelets.


### PR DESCRIPTION
Hi @kevinsantana11 / @selipot, I tried to fix `mypy` for all modules and failed (to say the least). I did this PR as a first step, we have a few arguments that were:
```
x: int | None = 0
```
which should simply be:
```
x: int = 0
```

To make typing a bit more easy for us, I think we should discuss a strategy. As of right now, we have a lot of functions that try to accept all types:
```
list | np.ndarray | pd.Series | xr.DataArray
```
but this is not constant across `clouddrift`, so for example, another function will have:
```
np.ndarray[float] | pd.Series | xr.DataArray
```
so if we pass a list somewhere `mypy` will complain.

Similarly, we are accepting `list` at a few places alongside other `array_like` structures and do operations like (if `x` is `array_like`):
```
x / CONSTANT
x.shape
x.size
```
which are not valid if `isinstance(x, list)`.

My main questions are:
- do we really want to support all the types?
- what do other libraries do in that situation? Or someone knows what's the best practices here?

One solution could be to defined a `clouddrift_array_like_type` once, and then reused it.. Something we do in `pairs.py` with:
```
array_like = Union[list, np.ndarray, pd.Series, xr.DataArray]
```

Maybe we can copy this to a discussion?
