### PR TITLE
🐛 Simplify download_with_progress inputs and fix clean up logic

### DIFF
--- a/clouddrift/adapters/andro.py
+++ b/clouddrift/adapters/andro.py
@@ -41,7 +41,7 @@ def to_xarray(tmp_path: str | None = None):
 
     # get or update dataset
     local_file = f"{tmp_path}/{ANDRO_URL.split('/')[-1]}"
-    download_with_progress([(ANDRO_URL, local_file, None)])
+    download_with_progress([(ANDRO_URL, local_file)])
 
     # parse with panda
     col_names = [

--- a/clouddrift/adapters/gdp.py
+++ b/clouddrift/adapters/gdp.py
@@ -198,7 +198,7 @@ def fetch_netcdf(url: str, file: str):
     file : str
         Name of the file to save.
     """
-    download_with_progress([(url, file, None)])
+    download_with_progress([(url, file)])
 
 
 def decode_date(t):

--- a/clouddrift/adapters/gdp1h.py
+++ b/clouddrift/adapters/gdp1h.py
@@ -107,7 +107,7 @@ def download(
             filelist = sorted(rng.choice(filelist, n_random_id, replace=False))
 
     download_with_progress(
-        [(f"{url}/{f}", os.path.join(tmp_path, f), None) for f in filelist]
+        [(f"{url}/{f}", os.path.join(tmp_path, f)) for f in filelist]
     )
     # Download the metadata so we can order the drifter IDs by end date.
     gdp_metadata = gdp.get_gdp_metadata()

--- a/clouddrift/adapters/gdp6h.py
+++ b/clouddrift/adapters/gdp6h.py
@@ -100,10 +100,7 @@ def download(
             drifter_urls = list(rng.choice(drifter_urls, n_random_id, replace=False))
 
     download_with_progress(
-        [
-            (url, os.path.join(tmp_path, os.path.basename(url)), None)
-            for url in drifter_urls
-        ]
+        [(url, os.path.join(tmp_path, os.path.basename(url))) for url in drifter_urls]
     )
 
     # Download the metadata so we can order the drifter IDs by end date.

--- a/clouddrift/adapters/mosaic.py
+++ b/clouddrift/adapters/mosaic.py
@@ -60,7 +60,7 @@ def get_dataframes() -> tuple[pd.DataFrame, pd.DataFrame]:
     )
     sorted_data_urls = [data_urls[i] for i in sorted_indices]
     buffers = [BytesIO() for _ in range(len(sorted_data_urls))]
-    requests = [(url, buffer, None) for url, buffer in zip(sorted_data_urls, buffers)]
+    requests = [(url, buffer) for url, buffer in zip(sorted_data_urls, buffers)]
 
     download_with_progress(requests, desc="Downloading data")
     [b.seek(0) for b in buffers]

--- a/clouddrift/adapters/subsurface_floats.py
+++ b/clouddrift/adapters/subsurface_floats.py
@@ -34,7 +34,7 @@ SUBSURFACE_FLOATS_TMP_PATH = os.path.join(
 
 
 def download(file: str):
-    download_with_progress([(SUBSURFACE_FLOATS_DATA_URL, file, None)])
+    download_with_progress([(SUBSURFACE_FLOATS_DATA_URL, file)])
 
 
 def to_xarray(

--- a/clouddrift/adapters/yomaha.py
+++ b/clouddrift/adapters/yomaha.py
@@ -46,7 +46,7 @@ YOMAHA_TMP_PATH = os.path.join(tempfile.gettempdir(), "clouddrift", "yomaha")
 
 def download(tmp_path: str):
     download_requests = [
-        (url, f"{tmp_path}/{url.split('/')[-1]}", None) for url in YOMAHA_URLS[:-1]
+        (url, f"{tmp_path}/{url.split('/')[-1]}") for url in YOMAHA_URLS[:-1]
     ]
     download_with_progress(download_requests)
 
@@ -54,7 +54,7 @@ def download(tmp_path: str):
     filename = filename_gz.removesuffix(".gz")
 
     buffer = BytesIO()
-    download_with_progress([(YOMAHA_URLS[-1], buffer, None)])
+    download_with_progress([(YOMAHA_URLS[-1], buffer)])
 
     decompressed_fp = os.path.join(tmp_path, filename)
     with (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,9 @@ files = [
 ]
 
 [tool.pytest.ini_options]
-testpaths = ["tests/*_tests.py", "tests/adapters/*_tests.py"]
+testpaths = [
+  "tests/**/*_tests.py",
+]
 
 
 [[tool.mypy.overrides]]

--- a/tests/adapters/gdp1h_tests.py
+++ b/tests/adapters/gdp1h_tests.py
@@ -93,7 +93,6 @@ class gdp1h_tests(unittest.TestCase):
                     (
                         f"some-url.com/drifter_hourly_{did}.nc",
                         os.path.join("../some/path", f"drifter_hourly_{did}.nc"),
-                        None,
                     )
                     for did in drifter_ids
                 ]

--- a/tests/adapters/gdp6h_tests.py
+++ b/tests/adapters/gdp6h_tests.py
@@ -93,7 +93,6 @@ class gdp6h_tests(unittest.TestCase):
                     (
                         f"some-url.com/netcdf_1_5000/drifter_6h_{did}.nc",
                         os.path.join("../some/path", f"drifter_6h_{did}.nc"),
-                        None,
                     )
                     for did in ret_drifter_ids
                 ]


### PR DESCRIPTION
* File buffers were not being closed correctly when exceptions were raised
* Move buffer management logic to top level function
* Passed in buffers are no longer closed when an exception is raised.
* Pull expected size from Content-Length header