### PR TITLE
🔍 ignore errors when reading source files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Create coverage report
         shell: bash -l {0}
         run: |
-              coverage xml
+              coverage xml -i
       - name: Upload coverage report to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.10'
         uses: codecov/codecov-action@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         run: coverage run -m pytest -c pyproject.toml
       - name: Display report
         shell: bash -l {0}
-        run: coverage report
+        run: coverage report -i
       - name: Create coverage report
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
Windows environment coverage report could not be created because the github runner environment includes a folder that's missing the __init__.py file. 

Ignoring these kinds of errors fixes the CI builds and while we ignore code parsing errors it should be noted that our code is executed via unit test and statically analyzed by a linter and type checker before separately meaning that any kind of code parsing errors would be caught by those tools.