### PR TITLE
🐛 Refactor wavelet.py to use variable boundary in morse_wavelet_transfo…

### DIFF
--- a/clouddrift/wavelet.py
+++ b/clouddrift/wavelet.py
@@ -173,17 +173,17 @@ def morse_wavelet_transform(
         # imaginary case, divide by 2 the wavelet and return analytic and conjugate analytic
         if normalization == "bandpass":
             wtx_p = wavelet_transform(
-                0.5 * x, wavelet, boundary="mirror", time_axis=time_axis
+                0.5 * x, wavelet, boundary=boundary, time_axis=time_axis
             )
             wtx_n = wavelet_transform(
-                np.conj(0.5 * x), wavelet, boundary="mirror", time_axis=time_axis
+                np.conj(0.5 * x), wavelet, boundary=boundary, time_axis=time_axis
             )
         elif normalization == "energy":
             wtx_p = wavelet_transform(
-                x / np.sqrt(2), wavelet, boundary="mirror", time_axis=time_axis
+                x / np.sqrt(2), wavelet, boundary=boundary, time_axis=time_axis
             )
             wtx_n = wavelet_transform(
-                np.conj(x / np.sqrt(2)), wavelet, boundary="mirror", time_axis=time_axis
+                np.conj(x / np.sqrt(2)), wavelet, boundary=boundary, time_axis=time_axis
             )
         wtx = wtx_p, wtx_n
 


### PR DESCRIPTION
There was a mistake in `morse_wavelet_transfer` wherein the boundary condition input argument was not passed on properly to `wavelet_transform`. @kevinsantana11 please review; can we make a release immediately for this bug fix?