### PR TITLE
🐛 Fixes empty yomaha dataset Issue #542

### DIFF
--- a/clouddrift/adapters/yomaha.py
+++ b/clouddrift/adapters/yomaha.py
@@ -56,6 +56,8 @@ def download(tmp_path: str):
     buffer = BytesIO()
     download_with_progress([(YOMAHA_URLS[-1], buffer)])
 
+    buffer.seek(0)
+
     decompressed_fp = os.path.join(tmp_path, filename)
     with (
         open(decompressed_fp, "wb") as file,


### PR DESCRIPTION
We just needed to reset the position of the buffer so, when we save the dataset to disk, it saves all the data we just downloaded.