### PR TITLE
Sets fixed zarr package to version 2 issue #552

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,5 +17,5 @@ dependencies:
   - aiohttp>=3.8.4
   - requests>=2.31.0
   - scipy>=1.11.2
-  - zarr>=2.14.2
+  - zarr>=2.14.2,<3
   - tenacity>=8.2.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "requests>=2.31.0",
     "scipy>=1.11.2",
     "xarray>=2023.5.0",
-    "zarr>=2.14.2",
+    "zarr>=2.14.2,<3",
     "tenacity>=8.2.3",
 ]
 


### PR DESCRIPTION
This is addressing issue #552.

The solution should be to use zarr v2 until the proper parts of v2 are ported to v3.