### PR TITLE
⭐️ update 'GDP_VERSION' in gdp6h.py

### DIFF
--- a/clouddrift/adapters/gdp/gdp6h.py
+++ b/clouddrift/adapters/gdp/gdp6h.py
@@ -18,7 +18,7 @@ import clouddrift.adapters.gdp as gdp
 from clouddrift.adapters.utils import download_with_progress, standard_retry_protocol
 from clouddrift.raggedarray import RaggedArray
 
-GDP_VERSION = "July 2024"
+GDP_VERSION = "December 2024"
 
 GDP_DATA_URL = "https://www.aoml.noaa.gov/ftp/pub/phod/buoydata/6h"
 GDP_TMP_PATH = os.path.join(tempfile.gettempdir(), "clouddrift", "gdp6h")

--- a/clouddrift/datasets.py
+++ b/clouddrift/datasets.py
@@ -93,8 +93,8 @@ def gdp6h(decode_times: bool = True) -> xr.Dataset:
     Oceanographic and Meteorological Laboratory (AOML) accessible at
     https://www.aoml.noaa.gov/phod/gdp/index.php.
 
-    This returns the July 2024 version of the dataset including data from 1979-02-15:00:00:00Z
-    to 2024-08-16:12:00:00Z.
+    This returns the December 2024 version of the dataset including data from 1979-02-15:00:00:00Z
+    to 2025-01-20:00:00:00Z.
 
     Parameters
     ----------


### PR DESCRIPTION
Within adapters/gdp/gdp6h.py, I've changed the GDP_VERSION from July 2024 to December 2024, following the latest 6h QC update.