### PR TITLE
⭐️ Refactor adapters to return RaggedArray instances

### DIFF
--- a/clouddrift/adapters/glad.py
+++ b/clouddrift/adapters/glad.py
@@ -1,7 +1,7 @@
 """
 This module defines functions used to adapt the Grand LAgrangian Deployment
 (GLAD) CODE-style drifter trajectories dataset from the Consortium for Advanced Research
-on Transport of Hydrocarbon in the Environment (CARTHE) as a ragged-array Xarray Dataset.
+on Transport of Hydrocarbon in the Environment (CARTHE) as a ragged-array dataset.
 
 The datasets and their respective description are hosted at:
 
@@ -12,7 +12,7 @@ The datasets and their respective description are hosted at:
 Example
 -------
 >>> from clouddrift.adapters import glad
->>> ds = glad.to_xarray()
+>>> ra = glad.to_raggedarray()
 
 to retrieve the default `qc2` version of the dataset. To retrieve the `raw` or `qc1` versions, pass the
 version name as an argument to `to_xarray()`, e.g. `glad.to_xarray(version="raw")`.
@@ -29,9 +29,9 @@ from typing import Literal
 
 import numpy as np
 import pandas as pd
-import xarray as xr
 
 from clouddrift.adapters.utils import download_with_progress
+from clouddrift.raggedarray import RaggedArray
 
 GLAD_VERSIONS = Literal["raw", "qc1", "qc2"]
 URL_RAW = "https://data.griidc.org/api/file/download/163324"
@@ -79,69 +79,98 @@ def get_dataframe(version: GLAD_VERSIONS = "qc2") -> pd.DataFrame:
     return df
 
 
-def to_xarray(version: GLAD_VERSIONS = "qc2") -> xr.Dataset:
-    """Return a GLAD dataset version as a ragged-array Xarray Dataset."""
+def to_raggedarray(version: GLAD_VERSIONS = "qc2") -> RaggedArray:
+    """Return a GLAD dataset version as a RaggedArray instance.
+
+    Parameters
+    ----------
+    version : GLAD_VERSIONS, optional
+        Version of the GLAD dataset to retrieve. One of "raw", "qc1", "qc2".
+        Default is "qc2".
+
+    Returns
+    -------
+    RaggedArray
+        GLAD dataset as a ragged array.
+    """
     df = get_dataframe(version=version)
-    ds = df.to_xarray()
 
-    traj, rowsize = np.unique(ds.id, return_counts=True)
+    ids = df["id"].to_numpy()
+    traj, rowsize = np.unique(ids, return_counts=True)
 
-    # Make the dataset compatible with clouddrift functions.
-    ds = (
-        ds.swap_dims({"index": "obs"})
-        .drop_vars(["id", "index"])
-        .assign_coords(traj=traj)
-        .assign({"rowsize": ("traj", rowsize)})
-        .rename_vars({"obs": "time", "traj": "id"})
-    )
-
-    # Cast double floats to singles
-    for var in ds.variables:
-        if ds[var].dtype == "float64":
-            ds[var] = ds[var].astype("float32")
-
-    # Set variable attributes
-    ds["longitude"].attrs = {
-        "long_name": "longitude",
-        "standard_name": "longitude",
-        "units": "degrees_east",
-    }
-
-    ds["latitude"].attrs = {
-        "long_name": "latitude",
-        "standard_name": "latitude",
-        "units": "degrees_north",
-    }
-
-    ds["position_error"].attrs = {
-        "long_name": "position_error",
-        "units": "m",
-    }
-
-    ds["u"].attrs = {
-        "long_name": "eastward_sea_water_velocity",
-        "standard_name": "eastward_sea_water_velocity",
-        "units": "m s-1",
-    }
-
-    ds["v"].attrs = {
-        "long_name": "northward_sea_water_velocity",
-        "standard_name": "northward_sea_water_velocity",
-        "units": "m s-1",
-    }
-
-    ds["velocity_error"].attrs = {
-        "long_name": "velocity_error",
-        "units": "m s-1",
-    }
-
-    # Set global attributes
-    ds.attrs = {
+    attrs_global = {
         "title": "GLAD experiment CODE-style drifter trajectories (low-pass filtered, 15 minute interval records), northern Gulf of Mexico near DeSoto Canyon, July-October 2012",
         "institution": "Consortium for Advanced Research on Transport of Hydrocarbon in the Environment (CARTHE)",
         "source": "CODE-style drifters",
-        "history": "Downloaded from https://data.gulfresearchinitiative.org/data/R1.x134.073:0004 and post-processed into a ragged-array Xarray Dataset by CloudDrift",
+        "history": "Downloaded from https://data.gulfresearchinitiative.org/data/R1.x134.073:0004 and post-processed into a ragged-array dataset by CloudDrift",
         "references": "Özgökmen, Tamay. 2013. GLAD experiment CODE-style drifter trajectories (low-pass filtered, 15 minute interval records), northern Gulf of Mexico near DeSoto Canyon, July-October 2012. Distributed by: Gulf of Mexico Research Initiative Information and Data Cooperative (GRIIDC), Harte Research Institute, Texas A&M University–Corpus Christi. doi:10.7266/N7VD6WC8",
     }
 
-    return ds
+    attrs_variables = {
+        "id": {"long_name": "trajectory identifier"},
+        "time": {"long_name": "time"},
+        "rowsize": {
+            "long_name": "number of observations per trajectory",
+            "sample_dimension": "obs",
+            "units": "-",
+        },
+        "longitude": {
+            "long_name": "longitude",
+            "standard_name": "longitude",
+            "units": "degrees_east",
+        },
+        "latitude": {
+            "long_name": "latitude",
+            "standard_name": "latitude",
+            "units": "degrees_north",
+        },
+        "position_error": {
+            "long_name": "position_error",
+            "units": "m",
+        },
+        "u": {
+            "long_name": "eastward_sea_water_velocity",
+            "standard_name": "eastward_sea_water_velocity",
+            "units": "m s-1",
+        },
+        "v": {
+            "long_name": "northward_sea_water_velocity",
+            "standard_name": "northward_sea_water_velocity",
+            "units": "m s-1",
+        },
+        "velocity_error": {
+            "long_name": "velocity_error",
+            "units": "m s-1",
+        },
+    }
+
+    return RaggedArray(
+        coords={
+            "id": traj,
+            "time": df["obs"].to_numpy(dtype="datetime64[ns]"),
+        },
+        metadata={
+            "rowsize": rowsize.astype("int64"),
+        },
+        data={
+            "latitude": df["latitude"].to_numpy(dtype="float32"),
+            "longitude": df["longitude"].to_numpy(dtype="float32"),
+            "position_error": df["position_error"].to_numpy(dtype="float32"),
+            "u": df["u"].to_numpy(dtype="float32"),
+            "v": df["v"].to_numpy(dtype="float32"),
+            "velocity_error": df["velocity_error"].to_numpy(dtype="float32"),
+        },
+        attrs_global=attrs_global,
+        attrs_variables=attrs_variables,
+        name_dims={"traj": "rows", "obs": "obs"},
+        coord_dims={"id": "traj", "time": "obs"},
+        var_dims={
+            "rowsize": ["traj"],
+            "latitude": ["obs"],
+            "longitude": ["obs"],
+            "position_error": ["obs"],
+            "u": ["obs"],
+            "v": ["obs"],
+            "velocity_error": ["obs"],
+        },
+    )

--- a/clouddrift/adapters/glad.py
+++ b/clouddrift/adapters/glad.py
@@ -15,7 +15,7 @@ Example
 >>> ra = glad.to_raggedarray()
 
 to retrieve the default `qc2` version of the dataset. To retrieve the `raw` or `qc1` versions, pass the
-version name as an argument to `to_xarray()`, e.g. `glad.to_xarray(version="raw")`.
+version name as an argument to `to_raggedarray()`, e.g. `glad.to_raggedarray(version="raw")`.
 
 References
 ----------
@@ -93,7 +93,7 @@ def to_raggedarray(version: GLAD_VERSIONS = "qc2") -> RaggedArray:
     RaggedArray
         GLAD dataset as a ragged array.
     """
-    df = get_dataframe(version=version)
+    df = get_dataframe(version=version).sort_values(["id", "obs"])
 
     ids = df["id"].to_numpy()
     traj, rowsize = np.unique(ids, return_counts=True)

--- a/clouddrift/adapters/mosaic.py
+++ b/clouddrift/adapters/mosaic.py
@@ -16,7 +16,7 @@ doi:10.18739/A2KP7TS83.
 Example
 -------
 >>> from clouddrift.adapters import mosaic
->>> ds = mosaic.to_xarray()
+>>> ra = mosaic.to_raggedarray()
 """
 
 import xml.etree.ElementTree as ET
@@ -26,9 +26,9 @@ from io import BytesIO
 import numpy as np
 import pandas as pd
 import requests
-import xarray as xr
 
 from clouddrift.adapters.utils import download_with_progress, standard_retry_protocol
+from clouddrift.raggedarray import RaggedArray
 
 MOSAIC_VERSION = "2022"
 
@@ -97,9 +97,14 @@ def get_repository_metadata() -> bytes:
     return r.content
 
 
-def to_xarray():
-    """Return the MOSAiC data as an ragged-array Xarray Dataset."""
+def to_raggedarray() -> RaggedArray:
+    """Return the MOSAiC data as a RaggedArray instance.
 
+    Returns
+    -------
+    RaggedArray
+        MOSAiC sea-ice drift trajectories as a ragged array.
+    """
     # Download the data and metadata as pandas DataFrames.
     obs_df, traj_df = get_dataframes()
 
@@ -112,30 +117,14 @@ def to_xarray():
         "First Data Datetime",
         "Last Data Datetime",
     ]:
-        traj_df[col] = pd.to_datetime(traj_df[col])
+        if col in traj_df.columns:
+            traj_df[col] = pd.to_datetime(traj_df[col])
 
-    # Merge into an Xarray Dataset and rename the dimensions and variables to
-    # follow the CloudDrift convention.
-    ds = xr.merge([obs_df.to_xarray(), traj_df.to_xarray()])
-    ds = ds.rename_dims({"datetime": "obs", "Sensor ID": "traj"}).rename_vars(
-        {"datetime": "time", "Sensor ID": "id"}
-    )
+    traj_ids = traj_df.index.to_numpy()
+    rowsize = traj_df["rowsize"].to_numpy(dtype="int64")
+    time = obs_df.index.to_numpy().astype("datetime64[ns]")
 
-    # Set variable attributes
-    ds["longitude"].attrs = {
-        "long_name": "longitude",
-        "standard_name": "longitude",
-        "units": "degrees_east",
-    }
-
-    ds["latitude"].attrs = {
-        "long_name": "latitude",
-        "standard_name": "latitude",
-        "units": "degrees_north",
-    }
-
-    # global attributes
-    ds.attrs = {
+    attrs_global = {
         "title": "Multidisciplinary drifting Observatory for the Study of Arctic Climate (MOSAiC) expedition 2019 - 2021",
         "history": f"Dataset updated in {MOSAIC_VERSION}",
         "date_created": datetime.now().isoformat(),
@@ -144,4 +133,59 @@ def to_xarray():
         "license": "Creative Commons Attribution 4.0 International License (http://creativecommons.org/licenses/by/4.0/)",
     }
 
-    return ds
+    attrs_variables = {
+        "id": {"long_name": "sensor identifier"},
+        "time": {"long_name": "time"},
+        "rowsize": {
+            "long_name": "number of observations per trajectory",
+            "sample_dimension": "obs",
+            "units": "-",
+        },
+        "latitude": {
+            "long_name": "latitude",
+            "standard_name": "latitude",
+            "units": "degrees_north",
+        },
+        "longitude": {
+            "long_name": "longitude",
+            "standard_name": "longitude",
+            "units": "degrees_east",
+        },
+    }
+
+    # Build traj-level metadata from all traj_df columns (rowsize handled separately)
+    traj_meta: dict = {}
+    traj_var_dims: dict = {}
+    for col in traj_df.columns:
+        if col == "rowsize":
+            continue
+        traj_meta[col] = traj_df[col].to_numpy()
+        traj_var_dims[col] = ["traj"]
+
+    # Build obs-level data from all obs_df columns
+    obs_data: dict = {}
+    obs_var_dims: dict = {}
+    for col in obs_df.columns:
+        obs_data[col] = obs_df[col].to_numpy()
+        obs_var_dims[col] = ["obs"]
+
+    return RaggedArray(
+        coords={
+            "id": traj_ids,
+            "time": time,
+        },
+        metadata={
+            "rowsize": rowsize,
+            **traj_meta,
+        },
+        data=obs_data,
+        attrs_global=attrs_global,
+        attrs_variables=attrs_variables,
+        name_dims={"traj": "rows", "obs": "obs"},
+        coord_dims={"id": "traj", "time": "obs"},
+        var_dims={
+            "rowsize": ["traj"],
+            **traj_var_dims,
+            **obs_var_dims,
+        },
+    )

--- a/clouddrift/adapters/quicche.py
+++ b/clouddrift/adapters/quicche.py
@@ -8,9 +8,9 @@ The dataset contains CARTHE surface drifter trajectories from the Cape Basin
 Example
 -------
 >>> from clouddrift.adapters import quicche
->>> ds = quicche.to_xarray()
->>> ds = quicche.to_xarray(version="qc1")
->>> ds = quicche.to_xarray(version="raw")
+>>> ra = quicche.to_raggedarray()
+>>> ra = quicche.to_raggedarray(version="qc1")
+>>> ra = quicche.to_raggedarray(version="raw")
 
 Reference
 ---------
@@ -24,9 +24,9 @@ from datetime import datetime
 from typing import Literal
 
 import pandas as pd
-import xarray as xr
 
 from clouddrift.adapters.utils import download_with_progress
+from clouddrift.raggedarray import RaggedArray
 
 # Zenodo record and URL
 QUICCHE_ZENODO_RECORD = "14902851"
@@ -34,13 +34,13 @@ QUICCHE_URL = "https://zenodo.org/records/14902851/files/CARTHE_Drifters_NSF_QUI
 QUICCHE_TMP_PATH = os.path.join(tempfile.gettempdir(), "clouddrift", "quicche")
 
 
-def to_xarray(
+def to_raggedarray(
     version: Literal["raw", "qc1", "qc2", "qc3"] = "qc3",
     tmp_path: str | None = None,
     skip_download: bool = False,
-) -> xr.Dataset:
+) -> RaggedArray:
     """
-    Parse and convert QUICCHE CARTHE drifter data to an xarray Dataset.
+    Parse and convert QUICCHE CARTHE drifter data to a RaggedArray instance.
 
     Parameters
     ----------
@@ -59,7 +59,7 @@ def to_xarray(
 
     Returns
     -------
-    xarray.Dataset
+    RaggedArray
         QUICCHE CARTHE drifter trajectories as a ragged array with dimensions
         (traj, obs) and coordinates (id, time).
     """
@@ -85,10 +85,10 @@ def to_xarray(
     # Parse the data file
     df = _parse_quicche_data(extracted_file, version)
 
-    # Convert to ragged array xarray Dataset
-    ds = _dataframe_to_ragged_xarray(df, version)
+    # Convert to ragged array
+    ra = _dataframe_to_raggedarray(df, version)
 
-    return ds
+    return ra
 
 
 def _extract_qc_file(zip_path: str, target_filename: str, extract_path: str) -> str:
@@ -235,9 +235,9 @@ def _parse_quicche_data(
     return df
 
 
-def _dataframe_to_ragged_xarray(df: pd.DataFrame, version: str) -> xr.Dataset:
+def _dataframe_to_raggedarray(df: pd.DataFrame, version: str) -> RaggedArray:
     """
-    Convert a trajectory DataFrame to a ragged array xarray Dataset.
+    Convert a trajectory DataFrame to a RaggedArray instance.
 
     Parameters
     ----------
@@ -248,75 +248,14 @@ def _dataframe_to_ragged_xarray(df: pd.DataFrame, version: str) -> xr.Dataset:
 
     Returns
     -------
-    xr.Dataset
-        Ragged array dataset with dimensions (traj, obs).
+    RaggedArray
+        Ragged array with dimensions (traj, obs).
     """
     # Compute rowsize and unique IDs
     rowsize_series = df.groupby("drifter_id", sort=True).size()
     unique_ids = rowsize_series.index.to_numpy()
     rowsize = rowsize_series.to_numpy(dtype="int64")
-    # Replicate drifter_id for each observation row
-    ds = xr.Dataset.from_dataframe(df)
 
-    # Rename the implicit dataframe index dimension to obs and drop the
-    # redundant coordinate variable that only mirrors the observation index.
-    ds = ds.rename_dims({"index": "obs"})
-
-    # Assign trajectory-level coordinates
-    ds = ds.assign({"id": ("traj", unique_ids)})
-    ds = ds.assign({"rowsize": ("traj", rowsize)})
-
-    # Drop per-observation drifter_id and the redundant dataframe index coordinate.
-    ds = ds.drop_vars(["drifter_id", "index"])
-
-    # Set coordinates
-    ds = ds.set_coords(["id", "time"])
-
-    # Cast dtypes to project conventions
-    ds["latitude"] = ds["latitude"].astype("float32")
-    ds["longitude"] = ds["longitude"].astype("float32")
-    ds["rowsize"] = ds["rowsize"].astype("int64")
-
-    # Define variable attributes
-    var_attrs = {
-        "latitude": {
-            "long_name": "Latitude of drifter position",
-            "units": "degrees_north",
-        },
-        "longitude": {
-            "long_name": "Longitude of drifter position",
-            "units": "degrees_east",
-        },
-        "time": {
-            "long_name": "Time of observation",
-            "comment": "UTC timestamps parsed from source ISO 8601 strings ending with 'Z'",
-        },
-        "id": {
-            "long_name": "Drifter ID",
-            "units": "-",
-        },
-        "rowsize": {
-            "long_name": "Number of observations per trajectory",
-            "units": "-",
-        },
-        "battery_state": {
-            "long_name": "Battery state reported by manufacturer",
-            "comment": "Values include GOOD and LOW",
-            "units": "-",
-        },
-        "flag": {
-            "long_name": "QC1 position/test flag",
-            "comment": "PRE: pre-deployment test; BAD_POS: visually evaluated bad position; empty string: no issue",
-            "units": "-",
-        },
-    }
-
-    # Apply variable attributes
-    for var, attrs in var_attrs.items():
-        if var in ds.variables:
-            ds[var].attrs = attrs
-
-    # Define global attributes
     qc_description = {
         "raw": "raw data",
         "qc1": "raw data with pre-deployment GPS tests flagged",
@@ -324,7 +263,7 @@ def _dataframe_to_ragged_xarray(df: pd.DataFrame, version: str) -> xr.Dataset:
         "qc3": "QC2 interpolated on a regular 30 minute time grid",
     }
 
-    global_attrs = {
+    attrs_global = {
         "title": f"QUICCHE CARTHE Surface Drifter Trajectories ({version.upper()})",
         "summary": f"CARTHE surface drifter trajectories from the Cape Basin (South Atlantic), March 2023. QC level {version.upper()}: {qc_description[version]}",
         "source": "CARTHE surface drifters",
@@ -338,6 +277,57 @@ def _dataframe_to_ragged_xarray(df: pd.DataFrame, version: str) -> xr.Dataset:
         "qc_level": version,
     }
 
-    ds.attrs = global_attrs
+    attrs_variables = {
+        "id": {"long_name": "Drifter ID", "units": "-"},
+        "time": {
+            "long_name": "Time of observation",
+            "comment": "UTC timestamps parsed from source ISO 8601 strings ending with 'Z'",
+        },
+        "rowsize": {"long_name": "Number of observations per trajectory", "units": "-"},
+        "latitude": {"long_name": "Latitude of drifter position", "units": "degrees_north"},
+        "longitude": {"long_name": "Longitude of drifter position", "units": "degrees_east"},
+        "battery_state": {
+            "long_name": "Battery state reported by manufacturer",
+            "comment": "Values include GOOD and LOW",
+            "units": "-",
+        },
+        "flag": {
+            "long_name": "QC1 position/test flag",
+            "comment": "PRE: pre-deployment test; BAD_POS: visually evaluated bad position; empty string: no issue",
+            "units": "-",
+        },
+    }
 
-    return ds
+    data: dict = {
+        "latitude": df["latitude"].to_numpy(dtype="float32"),
+        "longitude": df["longitude"].to_numpy(dtype="float32"),
+    }
+    var_dims: dict = {
+        "rowsize": ["traj"],
+        "latitude": ["obs"],
+        "longitude": ["obs"],
+    }
+
+    if "battery_state" in df.columns:
+        data["battery_state"] = df["battery_state"].to_numpy()
+        var_dims["battery_state"] = ["obs"]
+
+    if "flag" in df.columns:
+        data["flag"] = df["flag"].to_numpy()
+        var_dims["flag"] = ["obs"]
+
+    return RaggedArray(
+        coords={
+            "id": unique_ids,
+            "time": df["time"].to_numpy(dtype="datetime64[ns]"),
+        },
+        metadata={
+            "rowsize": rowsize,
+        },
+        data=data,
+        attrs_global=attrs_global,
+        attrs_variables=attrs_variables,
+        name_dims={"traj": "rows", "obs": "obs"},
+        coord_dims={"id": "traj", "time": "obs"},
+        var_dims=var_dims,
+    )

--- a/clouddrift/adapters/subsurface_floats.py
+++ b/clouddrift/adapters/subsurface_floats.py
@@ -8,21 +8,20 @@ The dataset is hosted at https://www.aoml.noaa.gov/phod/float_traj/index.php
 Example
 -------
 >>> from clouddrift.adapters import subsurface_floats
->>> ds = subsurface_floats.to_xarray()
+>>> ra = subsurface_floats.to_raggedarray()
 """
 
 import os
 import tempfile
-import warnings
 from collections.abc import Hashable
 from datetime import datetime
 
 import numpy as np
 import pandas as pd
 import scipy.io  # type: ignore
-import xarray as xr
 
 from clouddrift.adapters.utils import download_with_progress
+from clouddrift.raggedarray import RaggedArray
 
 SUBSURFACE_FLOATS_DATA_URL = (
     "https://www.aoml.noaa.gov/phod/float_traj/files/allFloats_12122017.mat"
@@ -35,11 +34,11 @@ def download(file: str, skip_download: bool = False):
     download_with_progress([(SUBSURFACE_FLOATS_DATA_URL, file)], skip_download=skip_download)
 
 
-def to_xarray(
+def to_raggedarray(
     tmp_path: str | None = None,
     skip_download: bool = False,
-):
-    """Convert the subsurface floats dataset to an xarray Dataset.
+) -> RaggedArray:
+    """Convert the subsurface floats dataset to a RaggedArray instance.
 
     Parameters
     ----------
@@ -52,12 +51,12 @@ def to_xarray(
 
     Returns
     -------
-    xarray.Dataset
+    RaggedArray
         Subsurface float trajectories as a ragged array.
     """
     if tmp_path is None:
         tmp_path = SUBSURFACE_FLOATS_TMP_PATH
-        os.makedirs(tmp_path, exist_ok=True)
+    os.makedirs(tmp_path, exist_ok=True)
 
     local_file = f"{tmp_path}/{SUBSURFACE_FLOATS_DATA_URL.split('/')[-1]}"
     download(local_file, skip_download=skip_download)
@@ -89,10 +88,10 @@ def to_xarray(
 
     # data
     data_variables = ["dtnum", "lon", "lat", "p", "t", "u", "v"]
-    data = {}
+    raw_data = {}
     for var in data_variables:
         arrs = _to_dense_flatten(source_data[str(var)])
-        data[var] = np.concatenate([_flatten_array(v) for v in arrs])
+        raw_data[var] = np.concatenate([_flatten_array(v) for v in arrs])
 
     # create rowsize variable
     arrs = _to_dense_flatten(source_data["dtnum"])
@@ -100,38 +99,11 @@ def to_xarray(
 
     # Unix epoch start (1970-01-01)
     origin_datenum = 719529
-
-    ds = xr.Dataset(
-        {
-            "expList": (["traj"], metadata["expList"]),
-            "expName": (["traj"], metadata["expName"]),
-            "expOrg": (["traj"], metadata["expOrg"]),
-            "expPI": (["traj"], metadata["expPI"]),
-            "indexExp": (["traj"], metadata["indexExp"]),
-            "fltType": (["traj"], metadata["fltType"]),
-            "id": (["traj"], metadata["indexFlt"]),
-            "rowsize": (["traj"], rowsize),
-            "time": (
-                ["obs"],
-                pd.to_datetime(data["dtnum"] - origin_datenum, unit="D"),
-            ),
-            "lon": (["obs"], data["lon"]),
-            "lat": (["obs"], data["lat"]),
-            "pres": (["obs"], data["p"]),
-            "temp": (["obs"], data["t"]),
-            "ve": (["obs"], data["u"]),
-            "vn": (["obs"], data["v"]),
-        }
+    time = pd.to_datetime(raw_data["dtnum"] - origin_datenum, unit="D").to_numpy(
+        dtype="datetime64[ns]"
     )
 
-    # Cast double floats to singles
-    double_vars = ["lat", "lon"]
-    for var in [v for v in ds.variables if v not in double_vars]:
-        if ds[var].dtype == "float64":
-            ds[var] = ds[var].astype("float32")
-
-    # define attributes
-    vars_attrs = {
+    attrs_variables = {
         "expList": {
             "long_name": "Experiment list",
             "units": "-",
@@ -158,6 +130,12 @@ def to_xarray(
             "units": "-",
         },
         "id": {"long_name": "Float ID", "units": "-"},
+        "time": {"long_name": "time"},
+        "rowsize": {
+            "long_name": "Number of observations per trajectory",
+            "sample_dimension": "obs",
+            "units": "-",
+        },
         "lon": {
             "long_name": "Longitude",
             "standard_name": "longitude",
@@ -167,11 +145,6 @@ def to_xarray(
             "long_name": "Latitude",
             "standard_name": "latitude",
             "units": "degrees_north",
-        },
-        "rowsize": {
-            "long_name": "Number of observations per trajectory",
-            "sample_dimension": "obs",
-            "units": "-",
         },
         "pres": {
             "long_name": "Pressure",
@@ -195,8 +168,7 @@ def to_xarray(
         },
     }
 
-    # global attributes
-    attrs = {
+    attrs_global = {
         "title": "Subsurface float trajectories dataset",
         "history": SUBSURFACE_FLOATS_VERSION,
         "date_created": datetime.now().isoformat(),
@@ -206,18 +178,48 @@ def to_xarray(
         "acknowledgement": "Maintained by Andree Ramsey and Heather Furey from the Woods Hole Oceanographic Institution",
     }
 
-    # set attributes
-    for var in vars_attrs.keys():
-        if var in ds.keys():
-            ds[var].attrs = vars_attrs[var]
-        else:
-            warnings.warn(f"Variable {var} not found in upstream data; skipping.")
-    ds.attrs = attrs
-
-    # set coordinates
-    ds = ds.set_coords(["time", "id"])
-
-    return ds
+    return RaggedArray(
+        coords={
+            "id": metadata["indexFlt"],
+            "time": time,
+        },
+        metadata={
+            "rowsize": rowsize.astype("int64"),
+            "expList": metadata["expList"],
+            "expName": metadata["expName"],
+            "expOrg": metadata["expOrg"],
+            "expPI": metadata["expPI"],
+            "indexExp": metadata["indexExp"],
+            "fltType": metadata["fltType"],
+        },
+        data={
+            "lon": raw_data["lon"],
+            "lat": raw_data["lat"],
+            "pres": raw_data["p"].astype("float32"),
+            "temp": raw_data["t"].astype("float32"),
+            "ve": raw_data["u"].astype("float32"),
+            "vn": raw_data["v"].astype("float32"),
+        },
+        attrs_global=attrs_global,
+        attrs_variables=attrs_variables,
+        name_dims={"traj": "rows", "obs": "obs"},
+        coord_dims={"id": "traj", "time": "obs"},
+        var_dims={
+            "rowsize": ["traj"],
+            "expList": ["traj"],
+            "expName": ["traj"],
+            "expOrg": ["traj"],
+            "expPI": ["traj"],
+            "indexExp": ["traj"],
+            "fltType": ["traj"],
+            "lon": ["obs"],
+            "lat": ["obs"],
+            "pres": ["obs"],
+            "temp": ["obs"],
+            "ve": ["obs"],
+            "vn": ["obs"],
+        },
+    )
 
 
 def _flatten_array(arr):

--- a/clouddrift/adapters/yomaha.py
+++ b/clouddrift/adapters/yomaha.py
@@ -9,7 +9,7 @@ is available at http://apdrc.soest.hawaii.edu/projects/yomaha/yomaha07/YoMaHa070
 Example
 -------
 >>> from clouddrift.adapters import yomaha
->>> ds = yomaha.to_xarray()
+>>> ra = yomaha.to_raggedarray()
 
 Reference
 ---------
@@ -21,15 +21,14 @@ import logging
 import os
 import shutil
 import tempfile
-import warnings
 from datetime import datetime
 from io import BytesIO
 
 import numpy as np
 import pandas as pd
-import xarray as xr
 
 from clouddrift.adapters.utils import download_with_progress
+from clouddrift.raggedarray import RaggedArray
 
 _logger = logging.getLogger(__name__)
 YOMAHA_URLS = [
@@ -67,8 +66,8 @@ def download(tmp_path: str, skip_download: bool = False):
             shutil.copyfileobj(compressed_file, file)
 
 
-def to_xarray(tmp_path: str | None = None, skip_download: bool = False):
-    """Convert the YoMaHa'07 dataset to an xarray Dataset.
+def to_raggedarray(tmp_path: str | None = None, skip_download: bool = False) -> RaggedArray:
+    """Convert the YoMaHa'07 dataset to a RaggedArray instance.
 
     Parameters
     ----------
@@ -82,12 +81,12 @@ def to_xarray(tmp_path: str | None = None, skip_download: bool = False):
 
     Returns
     -------
-    xarray.Dataset
-        YoMaHa'07 dataset as an xarray Dataset.
+    RaggedArray
+        YoMaHa'07 dataset as a ragged array.
     """
     if tmp_path is None:
         tmp_path = YOMAHA_TMP_PATH
-        os.makedirs(tmp_path, exist_ok=True)
+    os.makedirs(tmp_path, exist_ok=True)
 
     # get or update required files
     download(tmp_path, skip_download=skip_download)
@@ -97,7 +96,7 @@ def to_xarray(tmp_path: str | None = None, skip_download: bool = False):
         YOMAHA_VERSION = f.read().strip()
         print(f"Last database update was: {YOMAHA_VERSION}")
 
-    # parse with panda
+    # parse with pandas
     col_names = [
         "lon_d",
         "lat_d",
@@ -165,17 +164,13 @@ def to_xarray(tmp_path: str | None = None, skip_download: bool = False):
         )
     )
 
-    # open with pandas
     filename_gz = f"{tmp_path}/{YOMAHA_URLS[-1].split('/')[-1]}"
     filename = filename_gz.removesuffix(".gz")
     df = pd.read_csv(filename, names=col_names, sep=r"\s+", header=None, na_values=na_col)
 
-    # convert to an Xarray Dataset
-    ds = xr.Dataset.from_dataframe(df)
+    unique_id, rowsize = np.unique(df["id"], return_counts=True)
 
-    unique_id, rowsize = np.unique(ds["id"], return_counts=True)
-
-    # mapping of yomaha float id, wmo float id, daq id and float type
+    # mapping of yomaha float id, wmo float id, dac id and float type
     df_wmo = pd.read_csv(
         f"{tmp_path}/{YOMAHA_URLS[3].split('/')[-1]}",
         sep=r"\s+",
@@ -202,9 +197,6 @@ def to_xarray(tmp_path: str | None = None, skip_download: bool = False):
         names=["float_type_id", "float_type"],
         engine="python",
     )
-    # there is a note on METOCEAN * in float_types.txt but the
-    # float id, wmo id, and float type do not match (?)
-    # so we remove the * from the type
     df_float.loc[df_float["float_type_id"] == 0, "float_type"] = "METOCEAN"
 
     df_wmo["dac_id"] = df_wmo["dac_id"].astype("int64")
@@ -217,19 +209,8 @@ def to_xarray(tmp_path: str | None = None, skip_download: bool = False):
         .loc[lambda x: np.isin(x["id"], unique_id)]
     )
 
-    ds = (
-        ds.rename_dims({"index": "obs"})
-        .assign({"id": ("traj", unique_id)})
-        .assign({"rowsize": ("traj", rowsize)})
-        .assign({"wmo_id": ("traj", df_metadata["wmo_id"])})
-        .assign({"dac_id": ("traj", df_metadata["dac_id"])})
-        .assign({"float_type": ("traj", df_metadata["float_type_id"])})
-        .set_coords(["id", "time_d", "time_s", "time_lp", "time_lc", "time_lp"])
-        .drop_vars(["index"])
-    )
-
-    # Cast double floats to singles
-    double_vars = [
+    # float64 variables to keep as float64
+    double_vars = {
         "lat_d",
         "lon_d",
         "lat_s",
@@ -238,13 +219,30 @@ def to_xarray(tmp_path: str | None = None, skip_download: bool = False):
         "lon_lp",
         "lat_lc",
         "lon_lc",
-    ]
-    for var in [v for v in ds.variables if v not in double_vars]:
-        if ds[var].dtype == "float64":
-            ds[var] = ds[var].astype("float32")
+    }
 
-    # define attributes
-    vars_attrs = {
+    # time coordinate columns (stored as float, decoded by xarray via units attr)
+    time_coord_names = ["time_d", "time_s", "time_lp", "time_fc", "time_lc"]
+
+    # obs-level data columns (all except id and time coords)
+    obs_data_names = [c for c in col_names if c not in ("id",) + tuple(time_coord_names)]
+
+    def _cast(arr, name):
+        if name in double_vars:
+            return arr.to_numpy(dtype="float64")
+        if arr.dtype == "float64":
+            return arr.to_numpy(dtype="float32")
+        return arr.to_numpy()
+
+    coords = {
+        "id": unique_id,
+    }
+    for tc in time_coord_names:
+        coords[tc] = _cast(df[tc], tc)
+
+    data = {c: _cast(df[c], c) for c in obs_data_names}
+
+    attrs_variables = {
         "lon_d": {
             "long_name": "Longitude of the location where the deep velocity is calculated",
             "units": "degrees_east",
@@ -372,10 +370,14 @@ def to_xarray(tmp_path: str | None = None, skip_download: bool = False):
             "description": "1: APEX, 2: SOLO, 3: PROVOR, 4: R1, 5: MARTEC, 6: PALACE, 7: NINJA, 8: NEMO, 9: ALACE, 0: METOCEAN",
             "units": "-",
         },
+        "rowsize": {
+            "long_name": "number of observations per trajectory",
+            "sample_dimension": "obs",
+            "units": "-",
+        },
     }
 
-    # global attributes
-    attrs = {
+    attrs_global = {
         "title": "YoMaHa'07: Velocity data assessed from trajectories of Argo floats at parking level and at the sea surface",
         "history": f"Dataset updated on {YOMAHA_VERSION}",
         "date_created": datetime.now().isoformat(),
@@ -384,12 +386,31 @@ def to_xarray(tmp_path: str | None = None, skip_download: bool = False):
         "license": "freely available",
     }
 
-    # set attributes
-    for var in vars_attrs.keys():
-        if var in ds.keys():
-            ds[var].attrs = vars_attrs[var]
-        else:
-            warnings.warn(f"Variable {var} not found in upstream data; skipping.")
-    ds.attrs = attrs
+    coord_dims = {"id": "traj"}
+    for tc in time_coord_names:
+        coord_dims[tc] = "obs"
 
-    return ds
+    var_dims = {
+        "rowsize": ["traj"],
+        "wmo_id": ["traj"],
+        "dac_id": ["traj"],
+        "float_type": ["traj"],
+    }
+    for c in obs_data_names:
+        var_dims[c] = ["obs"]
+
+    return RaggedArray(
+        coords=coords,
+        metadata={
+            "rowsize": rowsize.astype("int64"),
+            "wmo_id": df_metadata["wmo_id"].to_numpy(),
+            "dac_id": df_metadata["dac_id"].to_numpy(),
+            "float_type": df_metadata["float_type_id"].to_numpy(),
+        },
+        data=data,
+        attrs_global=attrs_global,
+        attrs_variables=attrs_variables,
+        name_dims={"traj": "rows", "obs": "obs"},
+        coord_dims=coord_dims,
+        var_dims=var_dims,
+    )

--- a/clouddrift/adapters/yomaha.py
+++ b/clouddrift/adapters/yomaha.py
@@ -202,11 +202,14 @@ def to_raggedarray(tmp_path: str | None = None, skip_download: bool = False) -> 
     df_wmo["dac_id"] = df_wmo["dac_id"].astype("int64")
     df_dac["dac_id"] = df_dac["dac_id"].astype("int64")
 
-    # combine metadata
+    # combine metadata, aligned to the sorted unique_id order
     df_metadata = (
         pd.merge(df_wmo, df_dac, on="dac_id", how="left")
         .merge(df_float, on="float_type_id", how="left")
         .loc[lambda x: np.isin(x["id"], unique_id)]
+        .set_index("id")
+        .reindex(unique_id)
+        .reset_index()
     )
 
     # float64 variables to keep as float64
@@ -217,6 +220,8 @@ def to_raggedarray(tmp_path: str | None = None, skip_download: bool = False) -> 
         "lon_s",
         "lat_lp",
         "lon_lp",
+        "lat_fc",
+        "lon_fc",
         "lat_lc",
         "lon_lc",
     }

--- a/clouddrift/datasets.py
+++ b/clouddrift/datasets.py
@@ -565,7 +565,9 @@ def mosaic(decode_times: bool = True) -> xr.Dataset:
         rowsize                     (traj) int64 ...
     """
     return _dataset_filecache(
-        "mosaic.nc", decode_times, lambda: adapters.mosaic.to_raggedarray().to_xarray()
+        "mosaic.nc",
+        decode_times,
+        lambda: adapters.mosaic.to_raggedarray().to_xarray(),
     )
 
 

--- a/clouddrift/datasets.py
+++ b/clouddrift/datasets.py
@@ -564,7 +564,9 @@ def mosaic(decode_times: bool = True) -> xr.Dataset:
         Data Authors                (traj) object ...
         rowsize                     (traj) int64 ...
     """
-    return _dataset_filecache("mosaic.nc", decode_times, lambda: adapters.mosaic.to_raggedarray().to_xarray())
+    return _dataset_filecache(
+        "mosaic.nc", decode_times, lambda: adapters.mosaic.to_raggedarray().to_xarray()
+    )
 
 
 def spotters(decode_times: bool = True) -> xr.Dataset:
@@ -699,7 +701,9 @@ def subsurface_floats(decode_times: bool = True) -> xr.Dataset:
     WOCE Subsurface Float Data Assembly Center (WFDAC) https://www.aoml.noaa.gov/phod/float_traj/index.php
     """
     return _dataset_filecache(
-        "subsurface_floats.nc", decode_times, lambda: adapters.subsurface_floats.to_raggedarray().to_xarray()
+        "subsurface_floats.nc",
+        decode_times,
+        lambda: adapters.subsurface_floats.to_raggedarray().to_xarray(),
     )
 
 
@@ -766,7 +770,9 @@ def yomaha(decode_times: bool = True) -> xr.Dataset:
     assessed  from trajectories of Argo floats at parking level and at the sea
     surface. IPRC Technical Note, 4(2), 1-16.
     """
-    return _dataset_filecache("yomaha.nc", decode_times, lambda: adapters.yomaha.to_raggedarray().to_xarray())
+    return _dataset_filecache(
+        "yomaha.nc", decode_times, lambda: adapters.yomaha.to_raggedarray().to_xarray()
+    )
 
 
 def andro(decode_times: bool = True) -> xr.Dataset:

--- a/clouddrift/datasets.py
+++ b/clouddrift/datasets.py
@@ -293,7 +293,7 @@ def glad(decode_times: bool = True, version: GLAD_VERSIONS = "qc2") -> xr.Datase
     return _dataset_filecache(
         f"glad_{version}.nc",
         decode_times,
-        lambda: adapters.glad.to_xarray(version=version),
+        lambda: adapters.glad.to_raggedarray(version=version).to_xarray(),
     )
 
 
@@ -564,7 +564,7 @@ def mosaic(decode_times: bool = True) -> xr.Dataset:
         Data Authors                (traj) object ...
         rowsize                     (traj) int64 ...
     """
-    return _dataset_filecache("mosaic.nc", decode_times, adapters.mosaic.to_xarray)
+    return _dataset_filecache("mosaic.nc", decode_times, lambda: adapters.mosaic.to_raggedarray().to_xarray())
 
 
 def spotters(decode_times: bool = True) -> xr.Dataset:
@@ -699,7 +699,7 @@ def subsurface_floats(decode_times: bool = True) -> xr.Dataset:
     WOCE Subsurface Float Data Assembly Center (WFDAC) https://www.aoml.noaa.gov/phod/float_traj/index.php
     """
     return _dataset_filecache(
-        "subsurface_floats.nc", decode_times, adapters.subsurface_floats.to_xarray
+        "subsurface_floats.nc", decode_times, lambda: adapters.subsurface_floats.to_raggedarray().to_xarray()
     )
 
 
@@ -766,7 +766,7 @@ def yomaha(decode_times: bool = True) -> xr.Dataset:
     assessed  from trajectories of Argo floats at parking level and at the sea
     surface. IPRC Technical Note, 4(2), 1-16.
     """
-    return _dataset_filecache("yomaha.nc", decode_times, adapters.yomaha.to_xarray)
+    return _dataset_filecache("yomaha.nc", decode_times, lambda: adapters.yomaha.to_raggedarray().to_xarray())
 
 
 def andro(decode_times: bool = True) -> xr.Dataset:
@@ -901,7 +901,7 @@ def quicche(
     ds = _dataset_filecache(
         filename,
         decode_times,
-        lambda: adapters.quicche.to_xarray(version),
+        lambda: adapters.quicche.to_raggedarray(version).to_xarray(),
     )
 
     # Backward compatibility: rebuild stale cache files created before
@@ -913,7 +913,7 @@ def quicche(
         ds = _dataset_filecache(
             filename,
             decode_times,
-            lambda: adapters.quicche.to_xarray(version),
+            lambda: adapters.quicche.to_raggedarray(version).to_xarray(),
             force=True,
         )
 

--- a/tests/adapters/glad_test.py
+++ b/tests/adapters/glad_test.py
@@ -1,0 +1,122 @@
+import unittest
+from io import BytesIO
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+
+from clouddrift.adapters import glad
+from clouddrift.raggedarray import RaggedArray
+
+# Minimal GLAD CSV: 5 header lines then data rows
+_GLAD_CSV = (
+    b"% header1\n% header2\n% header3\n% header4\n% header5\n"
+    b"CARTHE_001 2012-07-20 18:00:00 29.5 -88.0 100.0 0.10 0.20 0.05\n"
+    b"CARTHE_001 2012-07-20 18:15:00 29.6 -87.9 110.0 0.11 0.21 0.06\n"
+    b"CARTHE_002 2012-07-20 18:00:00 29.0 -88.5 120.0 0.12 0.22 0.07\n"
+)
+
+
+def _mock_download(requests, **_kwargs):
+    """Write _GLAD_CSV into any BytesIO destination."""
+    for _, dest, *_ in requests:
+        if isinstance(dest, BytesIO):
+            dest.write(_GLAD_CSV)
+
+
+def _make_test_df():
+    return pd.DataFrame(
+        {
+            "id": ["CARTHE_001", "CARTHE_001", "CARTHE_002"],
+            "latitude": [29.5, 29.6, 29.0],
+            "longitude": [-88.0, -87.9, -88.5],
+            "position_error": [100.0, 110.0, 120.0],
+            "u": [0.10, 0.11, 0.12],
+            "v": [0.20, 0.21, 0.22],
+            "velocity_error": [0.05, 0.06, 0.07],
+            "obs": pd.to_datetime(
+                ["2012-07-20 18:00:00", "2012-07-20 18:15:00", "2012-07-20 18:00:00"]
+            ),
+        }
+    )
+
+
+class glad_tests(unittest.TestCase):
+    def test_get_dataframe_returns_expected_columns(self):
+        """get_dataframe returns a DataFrame with the expected columns."""
+        # Patch file_size to match the mock payload so the size check passes.
+        fake_versions = {"qc2": (glad._DATASET_VERSIONS["qc2"][0], len(_GLAD_CSV))}
+        with (
+            patch("clouddrift.adapters.glad._DATASET_VERSIONS", fake_versions),
+            patch(
+                "clouddrift.adapters.glad.download_with_progress",
+                side_effect=_mock_download,
+            ),
+        ):
+            df = glad.get_dataframe(version="qc2")
+
+        self.assertEqual(
+            list(df.columns),
+            ["id", "latitude", "longitude", "position_error", "u", "v", "velocity_error", "obs"],
+        )
+        self.assertEqual(len(df), 3)
+
+    def test_get_dataframe_raises_on_invalid_version(self):
+        """get_dataframe raises ValueError for an unknown version string."""
+        with self.assertRaises(ValueError):
+            glad.get_dataframe(version="invalid")
+
+    def test_to_raggedarray_returns_raggedarray(self):
+        """to_raggedarray returns a RaggedArray instance."""
+        with patch("clouddrift.adapters.glad.get_dataframe", return_value=_make_test_df()):
+            ra = glad.to_raggedarray()
+
+        self.assertIsInstance(ra, RaggedArray)
+
+    def test_to_raggedarray_dimensions(self):
+        """to_raggedarray produces correct traj and obs sizes."""
+        with patch("clouddrift.adapters.glad.get_dataframe", return_value=_make_test_df()):
+            ds = glad.to_raggedarray().to_xarray()
+
+        self.assertEqual(ds.sizes["traj"], 2)
+        self.assertEqual(ds.sizes["obs"], 3)
+
+    def test_to_raggedarray_rowsize(self):
+        """to_raggedarray computes per-trajectory rowsize correctly."""
+        with patch("clouddrift.adapters.glad.get_dataframe", return_value=_make_test_df()):
+            ra = glad.to_raggedarray()
+
+        self.assertTrue(np.array_equal(ra.metadata["rowsize"], [2, 1]))
+
+    def test_to_raggedarray_dtypes(self):
+        """to_raggedarray casts float columns to float32 and rowsize to int64."""
+        with patch("clouddrift.adapters.glad.get_dataframe", return_value=_make_test_df()):
+            ds = glad.to_raggedarray().to_xarray()
+
+        self.assertEqual(ds["latitude"].dtype, np.float32)
+        self.assertEqual(ds["longitude"].dtype, np.float32)
+        self.assertEqual(ds["rowsize"].dtype, np.int64)
+
+    def test_to_raggedarray_coords(self):
+        """to_raggedarray exposes id and time as coordinates."""
+        with patch("clouddrift.adapters.glad.get_dataframe", return_value=_make_test_df()):
+            ds = glad.to_raggedarray().to_xarray()
+
+        self.assertIn("id", ds.coords)
+        self.assertIn("time", ds.coords)
+
+    def test_to_raggedarray_data_vars(self):
+        """to_raggedarray includes all expected data variables."""
+        with patch("clouddrift.adapters.glad.get_dataframe", return_value=_make_test_df()):
+            ds = glad.to_raggedarray().to_xarray()
+
+        for var in [
+            "latitude",
+            "longitude",
+            "position_error",
+            "u",
+            "v",
+            "velocity_error",
+            "rowsize",
+        ]:
+            self.assertIn(var, ds)

--- a/tests/adapters/mosaic_test.py
+++ b/tests/adapters/mosaic_test.py
@@ -1,0 +1,113 @@
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+
+from clouddrift.adapters import mosaic
+from clouddrift.raggedarray import RaggedArray
+
+
+def _make_test_dataframes():
+    obs_df = pd.DataFrame(
+        {
+            "latitude": [89.5, 89.6, 89.4, 89.3, 89.2],
+            "longitude": [0.1, 0.2, 0.3, 0.4, 0.5],
+        },
+        index=pd.DatetimeIndex(
+            pd.to_datetime(["2020-01-01", "2020-01-02", "2020-01-03", "2020-01-04", "2020-01-05"]),
+            name="datetime",
+        ),
+    )
+    traj_df = pd.DataFrame(
+        {
+            "rowsize": [3, 2],
+            "Deployment Leg": [1, 2],
+            "Buoy Type": ["IMB", "SIMBA"],
+            "Deployment Date": ["2019-10-04", "2019-10-15"],
+            "Deployment Datetime": ["2019-10-04T12:00:00", "2019-10-15T09:00:00"],
+            "First Data Datetime": ["2020-01-01T00:00:00", "2020-01-04T00:00:00"],
+            "Last Data Datetime": ["2020-01-03T00:00:00", "2020-01-05T00:00:00"],
+        },
+        index=pd.Index(["SENSOR_001", "SENSOR_002"], name="Sensor ID"),
+    )
+    return obs_df, traj_df
+
+
+class mosaic_tests(unittest.TestCase):
+    def test_to_raggedarray_returns_raggedarray(self):
+        """to_raggedarray returns a RaggedArray instance."""
+        with patch(
+            "clouddrift.adapters.mosaic.get_dataframes",
+            return_value=_make_test_dataframes(),
+        ):
+            ra = mosaic.to_raggedarray()
+
+        self.assertIsInstance(ra, RaggedArray)
+
+    def test_to_raggedarray_dimensions(self):
+        """to_raggedarray produces correct traj and obs sizes."""
+        with patch(
+            "clouddrift.adapters.mosaic.get_dataframes",
+            return_value=_make_test_dataframes(),
+        ):
+            ds = mosaic.to_raggedarray().to_xarray()
+
+        self.assertEqual(ds.sizes["traj"], 2)
+        self.assertEqual(ds.sizes["obs"], 5)
+
+    def test_to_raggedarray_rowsize(self):
+        """to_raggedarray computes per-trajectory rowsize correctly."""
+        with patch(
+            "clouddrift.adapters.mosaic.get_dataframes",
+            return_value=_make_test_dataframes(),
+        ):
+            ra = mosaic.to_raggedarray()
+
+        self.assertTrue(np.array_equal(ra.metadata["rowsize"], [3, 2]))
+
+    def test_to_raggedarray_coords(self):
+        """to_raggedarray exposes id (Sensor ID) and time as coordinates."""
+        with patch(
+            "clouddrift.adapters.mosaic.get_dataframes",
+            return_value=_make_test_dataframes(),
+        ):
+            ds = mosaic.to_raggedarray().to_xarray()
+
+        self.assertIn("id", ds.coords)
+        self.assertIn("time", ds.coords)
+        self.assertTrue(np.array_equal(ds["id"].values, ["SENSOR_001", "SENSOR_002"]))
+
+    def test_to_raggedarray_traj_metadata(self):
+        """to_raggedarray includes all traj-level sensor columns as metadata."""
+        with patch(
+            "clouddrift.adapters.mosaic.get_dataframes",
+            return_value=_make_test_dataframes(),
+        ):
+            ds = mosaic.to_raggedarray().to_xarray()
+
+        self.assertIn("Deployment Leg", ds)
+        self.assertIn("Buoy Type", ds)
+        self.assertEqual(ds["Deployment Leg"].dims, ("traj",))
+
+    def test_to_raggedarray_datetime_columns_converted(self):
+        """to_raggedarray converts string datetime traj columns to datetime64."""
+        with patch(
+            "clouddrift.adapters.mosaic.get_dataframes",
+            return_value=_make_test_dataframes(),
+        ):
+            ds = mosaic.to_raggedarray().to_xarray()
+
+        self.assertTrue(np.issubdtype(ds["Deployment Date"].dtype, np.datetime64))
+
+    def test_to_raggedarray_data_vars(self):
+        """to_raggedarray includes latitude and longitude as obs-level data."""
+        with patch(
+            "clouddrift.adapters.mosaic.get_dataframes",
+            return_value=_make_test_dataframes(),
+        ):
+            ds = mosaic.to_raggedarray().to_xarray()
+
+        self.assertIn("latitude", ds)
+        self.assertIn("longitude", ds)
+        self.assertEqual(ds["latitude"].dims, ("obs",))

--- a/tests/adapters/quicche_test.py
+++ b/tests/adapters/quicche_test.py
@@ -98,7 +98,7 @@ class quicche_tests(unittest.TestCase):
             }
         )
 
-        ds = quicche._dataframe_to_ragged_xarray(df, "qc3")
+        ds = quicche._dataframe_to_raggedarray(df, "qc3").to_xarray()
 
         # Check dimensions
         self.assertIn("traj", ds.dims)
@@ -117,7 +117,7 @@ class quicche_tests(unittest.TestCase):
             }
         )
 
-        ds = quicche._dataframe_to_ragged_xarray(df, "qc2")
+        ds = quicche._dataframe_to_raggedarray(df, "qc2").to_xarray()
 
         # Check coordinates
         self.assertIn("id", ds.coords)
@@ -143,7 +143,7 @@ class quicche_tests(unittest.TestCase):
             }
         )
 
-        ds = quicche._dataframe_to_ragged_xarray(df, "qc1")
+        ds = quicche._dataframe_to_raggedarray(df, "qc1").to_xarray()
         self.assertIn("battery_state", ds.data_vars)
         self.assertIn("flag", ds.data_vars)
 
@@ -158,7 +158,7 @@ class quicche_tests(unittest.TestCase):
             }
         )
 
-        ds = quicche._dataframe_to_ragged_xarray(df, "qc3")
+        ds = quicche._dataframe_to_raggedarray(df, "qc3").to_xarray()
         self.assertNotIn("battery_state", ds.data_vars)
         self.assertNotIn("flag", ds.data_vars)
 
@@ -173,7 +173,7 @@ class quicche_tests(unittest.TestCase):
             }
         )
 
-        ds = quicche._dataframe_to_ragged_xarray(df, "qc3")
+        ds = quicche._dataframe_to_raggedarray(df, "qc3").to_xarray()
 
         rowsize = ds["rowsize"].values
         # Q1_0001 has 2 observations, Q1_0002 has 3
@@ -190,7 +190,7 @@ class quicche_tests(unittest.TestCase):
             }
         )
 
-        ds = quicche._dataframe_to_ragged_xarray(df, "qc3")
+        ds = quicche._dataframe_to_raggedarray(df, "qc3").to_xarray()
 
         # Check float32 for lat/lon
         self.assertEqual(ds["latitude"].dtype, np.float32)
@@ -210,10 +210,10 @@ class quicche_tests(unittest.TestCase):
             }
         )
 
-        ds_raw = quicche._dataframe_to_ragged_xarray(df, "raw")
-        ds_qc1 = quicche._dataframe_to_ragged_xarray(df, "qc1")
-        ds_qc2 = quicche._dataframe_to_ragged_xarray(df, "qc2")
-        ds_qc3 = quicche._dataframe_to_ragged_xarray(df, "qc3")
+        ds_raw = quicche._dataframe_to_raggedarray(df, "raw").to_xarray()
+        ds_qc1 = quicche._dataframe_to_raggedarray(df, "qc1").to_xarray()
+        ds_qc2 = quicche._dataframe_to_raggedarray(df, "qc2").to_xarray()
+        ds_qc3 = quicche._dataframe_to_raggedarray(df, "qc3").to_xarray()
 
         # Check version is in title and attributes
         self.assertIn("RAW", ds_raw.attrs["title"])
@@ -228,4 +228,4 @@ class quicche_tests(unittest.TestCase):
     def test_to_xarray_version_validation(self):
         """Test that invalid versions raise ValueError."""
         with self.assertRaises(ValueError):
-            quicche.to_xarray(version="invalid", tmp_path=self.test_dir)
+            quicche.to_raggedarray(version="invalid", tmp_path=self.test_dir)

--- a/tests/adapters/subsurface_floats_test.py
+++ b/tests/adapters/subsurface_floats_test.py
@@ -1,0 +1,137 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+
+from clouddrift.adapters import subsurface_floats
+from clouddrift.raggedarray import RaggedArray
+
+# Unix epoch day number (1970-01-01) used by the subsurface floats adapter
+_ORIGIN_DATENUM = 719529
+
+
+def _make_mat_data():
+    """Return a minimal mock scipy.io.loadmat output for 2 floats.
+
+    Float 1001 has 3 observations; float 1002 has 2 observations.
+    Each float belongs to its own experiment (EXP1 / EXP2).
+    """
+
+    def scalar_cells(*values):
+        arr = np.empty(len(values), dtype=object)
+        for i, v in enumerate(values):
+            arr[i] = np.array([v])
+        return arr
+
+    def array_cells(*arrays):
+        arr = np.empty(len(arrays), dtype=object)
+        for i, a in enumerate(arrays):
+            arr[i] = np.array(a, dtype=float)
+        return arr
+
+    return {
+        "expList": scalar_cells("EXP1", "EXP2"),
+        "expName": scalar_cells("Experiment 1", "Experiment 2"),
+        "expOrg": scalar_cells("WHOI", "AOML"),
+        "expPI": scalar_cells("Smith", "Jones"),
+        "fltType": scalar_cells("APEX", "SOLO"),
+        "indexExp": scalar_cells(1, 2),
+        "indexFlt": scalar_cells(1001, 1002),
+        "dtnum": array_cells(
+            [_ORIGIN_DATENUM + 1.0, _ORIGIN_DATENUM + 2.0, _ORIGIN_DATENUM + 3.0],
+            [_ORIGIN_DATENUM + 4.0, _ORIGIN_DATENUM + 5.0],
+        ),
+        "lon": array_cells([-10.0, -10.1, -10.2], [-20.0, -20.1]),
+        "lat": array_cells([45.0, 45.1, 45.2], [50.0, 50.1]),
+        "p": array_cells([100.0, 101.0, 102.0], [200.0, 201.0]),
+        "t": array_cells([10.0, 10.1, 10.2], [5.0, 5.1]),
+        "u": array_cells([0.1, 0.2, 0.3], [0.4, 0.5]),
+        "v": array_cells([0.2, 0.3, 0.4], [0.5, 0.6]),
+    }
+
+
+def _mock_download(requests, **_kwargs):
+    """Write a single non-empty byte so the file-size check passes."""
+    for _, dest, *_ in requests:
+        if isinstance(dest, str):
+            os.makedirs(os.path.dirname(dest), exist_ok=True)
+            with open(dest, "wb") as f:
+                f.write(b"\x00")
+
+
+class subsurface_floats_tests(unittest.TestCase):
+    def setUp(self):
+        self.tmp_path = tempfile.mkdtemp()
+
+    def _run_to_raggedarray(self):
+        with (
+            patch(
+                "clouddrift.adapters.subsurface_floats.download_with_progress",
+                side_effect=_mock_download,
+            ),
+            patch(
+                "clouddrift.adapters.subsurface_floats.scipy.io.loadmat",
+                return_value=_make_mat_data(),
+            ),
+            patch(
+                "clouddrift.adapters.subsurface_floats.os.path.getsize",
+                return_value=1,
+            ),
+        ):
+            return subsurface_floats.to_raggedarray(tmp_path=self.tmp_path)
+
+    def test_to_raggedarray_returns_raggedarray(self):
+        """to_raggedarray returns a RaggedArray instance."""
+        ra = self._run_to_raggedarray()
+        self.assertIsInstance(ra, RaggedArray)
+
+    def test_to_raggedarray_dimensions(self):
+        """to_raggedarray produces correct traj and obs sizes."""
+        ds = self._run_to_raggedarray().to_xarray()
+        self.assertEqual(ds.sizes["traj"], 2)
+        self.assertEqual(ds.sizes["obs"], 5)
+
+    def test_to_raggedarray_rowsize(self):
+        """to_raggedarray computes per-trajectory rowsize correctly."""
+        ra = self._run_to_raggedarray()
+        self.assertTrue(np.array_equal(ra.metadata["rowsize"], [3, 2]))
+
+    def test_to_raggedarray_coords(self):
+        """to_raggedarray exposes id and time as coordinates."""
+        ds = self._run_to_raggedarray().to_xarray()
+        self.assertIn("id", ds.coords)
+        self.assertIn("time", ds.coords)
+
+    def test_to_raggedarray_dtypes(self):
+        """to_raggedarray keeps lat/lon as float64 and casts others to float32."""
+        ds = self._run_to_raggedarray().to_xarray()
+        self.assertEqual(ds["lat"].dtype, np.float64)
+        self.assertEqual(ds["lon"].dtype, np.float64)
+        self.assertEqual(ds["pres"].dtype, np.float32)
+        self.assertEqual(ds["temp"].dtype, np.float32)
+        self.assertEqual(ds["ve"].dtype, np.float32)
+        self.assertEqual(ds["vn"].dtype, np.float32)
+
+    def test_to_raggedarray_traj_metadata(self):
+        """to_raggedarray includes expected traj-level metadata variables."""
+        ds = self._run_to_raggedarray().to_xarray()
+        for var in ["expList", "expName", "expOrg", "expPI", "fltType", "indexExp"]:
+            self.assertIn(var, ds)
+            self.assertEqual(ds[var].dims, ("traj",))
+
+    def test_to_raggedarray_raises_on_empty_file(self):
+        """to_raggedarray raises ConnectionError when the downloaded file is empty."""
+        with (
+            patch(
+                "clouddrift.adapters.subsurface_floats.download_with_progress",
+                side_effect=_mock_download,
+            ),
+            patch(
+                "clouddrift.adapters.subsurface_floats.os.path.getsize",
+                return_value=0,
+            ),
+        ):
+            with self.assertRaises(ConnectionError):
+                subsurface_floats.to_raggedarray(tmp_path=self.tmp_path)

--- a/tests/adapters/yomaha_test.py
+++ b/tests/adapters/yomaha_test.py
@@ -116,7 +116,18 @@ class yomaha_tests(unittest.TestCase):
     def test_to_raggedarray_dtypes(self):
         """to_raggedarray keeps lat/lon pairs as float64 and casts others to float32."""
         ds = self._run_to_raggedarray().to_xarray()
-        for var in ["lat_d", "lon_d", "lat_s", "lon_s", "lat_lp", "lon_lp", "lat_lc", "lon_lc"]:
+        for var in [
+            "lat_d",
+            "lon_d",
+            "lat_s",
+            "lon_s",
+            "lat_lp",
+            "lon_lp",
+            "lat_fc",
+            "lon_fc",
+            "lat_lc",
+            "lon_lc",
+        ]:
             self.assertEqual(ds[var].dtype, np.float64, msg=f"{var} should be float64")
         for var in ["ve_d", "vn_d", "pres_d"]:
             self.assertEqual(ds[var].dtype, np.float32, msg=f"{var} should be float32")

--- a/tests/adapters/yomaha_test.py
+++ b/tests/adapters/yomaha_test.py
@@ -1,0 +1,128 @@
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+
+from clouddrift.adapters import yomaha
+from clouddrift.raggedarray import RaggedArray
+
+# -------------------------------------------------------------------------
+# Minimal test-file content
+# -------------------------------------------------------------------------
+
+# float_types.txt: "float_type_id: float_type" rows + 4 footer lines (skipfooter=4)
+_FLOAT_TYPES_TXT = "1: APEX\n2: SOLO\n0: METOCEAN\nfooter1\nfooter2\nfooter3\nfooter4\n"
+
+# DACs.txt: "dac_id: dac_name"
+_DACS_TXT = "1: AOML\n2: CORIOLIS\n"
+
+# 0-date_time.txt: last update date string
+_DATE_TIME_TXT = "2024-01-15\n"
+
+# WMO2DAC2type.txt: "id wmo_id dac_id float_type_id" (whitespace-separated)
+_WMO2DAC2TYPE_TXT = "1001 9001 1 1\n1002 9002 1 2\n"
+
+# end-prog.lst: not read by to_raggedarray, just needs to exist
+_END_PROG_LST = ""
+
+# yomaha07.dat: 28 whitespace-separated columns per row (2 floats × 2 cycles)
+# Columns: lon_d lat_d pres_d time_d ve_d vn_d err_ve_d err_vn_d
+#          lon_s lat_s time_s ve_s vn_s err_ve_s err_vn_s
+#          lon_lp lat_lp time_lp lon_fc lat_fc time_fc lon_lc lat_lc time_lc
+#          surf_fix id cycle time_inv
+_YOMAHA_DAT = (
+    "180.0 45.0 1000.0 1000.0 10.0 10.0 1.0 1.0 "
+    "181.0 45.5 1001.0 5.0 5.0 0.5 0.5 "
+    "179.0 44.5 999.0 180.0 45.0 1000.0 181.0 45.5 1001.0 "
+    "3.0 1001.0 1.0 0.0\n"
+    "180.1 45.1 1000.0 1010.0 10.0 10.0 1.0 1.0 "
+    "181.1 45.6 1011.0 5.0 5.0 0.5 0.5 "
+    "180.0 45.0 1009.0 180.1 45.1 1010.0 181.1 45.6 1011.0 "
+    "3.0 1001.0 2.0 0.0\n"
+    "200.0 50.0 1000.0 1000.0 8.0 8.0 1.0 1.0 "
+    "201.0 50.5 1001.0 4.0 4.0 0.5 0.5 "
+    "199.0 49.5 999.0 200.0 50.0 1000.0 201.0 50.5 1001.0 "
+    "2.0 1002.0 1.0 0.0\n"
+    "200.1 50.1 1000.0 1010.0 8.0 8.0 1.0 1.0 "
+    "201.1 50.6 1011.0 4.0 4.0 0.5 0.5 "
+    "200.0 50.0 1009.0 200.1 50.1 1010.0 201.1 50.6 1011.0 "
+    "2.0 1002.0 2.0 0.0\n"
+)
+
+_FILE_CONTENTS = {
+    "float_types.txt": _FLOAT_TYPES_TXT,
+    "DACs.txt": _DACS_TXT,
+    "0-date_time.txt": _DATE_TIME_TXT,
+    "WMO2DAC2type.txt": _WMO2DAC2TYPE_TXT,
+    "end-prog.lst": _END_PROG_LST,
+    "yomaha07.dat": _YOMAHA_DAT,
+}
+
+
+def _create_test_files(tmp_path: str):
+    for filename, content in _FILE_CONTENTS.items():
+        with open(os.path.join(tmp_path, filename), "w") as f:
+            f.write(content)
+
+
+def _noop_download(*_args, **_kwargs):
+    """No-op mock for download_with_progress; files are pre-created."""
+    pass
+
+
+class yomaha_tests(unittest.TestCase):
+    def setUp(self):
+        self.tmp_path = tempfile.mkdtemp()
+        _create_test_files(self.tmp_path)
+
+    def _run_to_raggedarray(self):
+        with patch(
+            "clouddrift.adapters.yomaha.download_with_progress",
+            side_effect=_noop_download,
+        ):
+            return yomaha.to_raggedarray(tmp_path=self.tmp_path, skip_download=True)
+
+    def test_to_raggedarray_returns_raggedarray(self):
+        """to_raggedarray returns a RaggedArray instance."""
+        ra = self._run_to_raggedarray()
+        self.assertIsInstance(ra, RaggedArray)
+
+    def test_to_raggedarray_dimensions(self):
+        """to_raggedarray produces correct traj and obs sizes."""
+        ds = self._run_to_raggedarray().to_xarray()
+        self.assertEqual(ds.sizes["traj"], 2)
+        self.assertEqual(ds.sizes["obs"], 4)
+
+    def test_to_raggedarray_rowsize(self):
+        """to_raggedarray computes per-trajectory rowsize correctly."""
+        ra = self._run_to_raggedarray()
+        self.assertTrue(np.array_equal(ra.metadata["rowsize"], [2, 2]))
+
+    def test_to_raggedarray_time_coords(self):
+        """to_raggedarray exposes time_d, time_s, time_lp, time_fc, time_lc as coordinates."""
+        ds = self._run_to_raggedarray().to_xarray()
+        for tc in ["time_d", "time_s", "time_lp", "time_fc", "time_lc"]:
+            self.assertIn(tc, ds.coords)
+
+    def test_to_raggedarray_traj_metadata(self):
+        """to_raggedarray includes wmo_id, dac_id, float_type as traj-level metadata."""
+        ds = self._run_to_raggedarray().to_xarray()
+        for var in ["wmo_id", "dac_id", "float_type"]:
+            self.assertIn(var, ds)
+            self.assertEqual(ds[var].dims, ("traj",))
+
+    def test_to_raggedarray_dtypes(self):
+        """to_raggedarray keeps lat/lon pairs as float64 and casts others to float32."""
+        ds = self._run_to_raggedarray().to_xarray()
+        for var in ["lat_d", "lon_d", "lat_s", "lon_s", "lat_lp", "lon_lp", "lat_lc", "lon_lc"]:
+            self.assertEqual(ds[var].dtype, np.float64, msg=f"{var} should be float64")
+        for var in ["ve_d", "vn_d", "pres_d"]:
+            self.assertEqual(ds[var].dtype, np.float32, msg=f"{var} should be float32")
+
+    def test_to_raggedarray_id_coord(self):
+        """to_raggedarray exposes id as a traj-level coordinate."""
+        ds = self._run_to_raggedarray().to_xarray()
+        self.assertIn("id", ds.coords)
+        self.assertTrue(np.array_equal(ds["id"].values, [1001, 1002]))


### PR DESCRIPTION
- Updated `subsurface_floats`, `yomaha`, `glad`, and `mosaic` adapters to convert datasets to RaggedArray instead of xarray Dataset.
- Modified the `to_xarray` methods to return RaggedArray instances and adjusted the associated tests accordingly.
- Added new unit tests for `glad`, `mosaic`, `subsurface_floats`, and `yomaha` to ensure correct functionality of the new RaggedArray implementation.
- Updated dataset retrieval functions in `datasets.py` to accommodate the changes in adapter return types.